### PR TITLE
fix: gateway status always showing as offline

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ function git(cmd: string): string {
 }
 
 const nextConfig: NextConfig = {
+  turbopack: {},
   env: {
     NEXT_PUBLIC_APP_VERSION: git("describe --tags --always") || "dev",
     NEXT_PUBLIC_COMMIT_HASH: git("rev-parse --short HEAD") || "unknown",

--- a/src/app/api/gateway/route.ts
+++ b/src/app/api/gateway/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { runCliJson } from "@/lib/openclaw";
-import { getOpenClawBin } from "@/lib/paths";
+import { getOpenClawBin, getGatewayUrl } from "@/lib/paths";
 import { execFile } from "child_process";
 import { promisify } from "util";
 
@@ -18,58 +18,75 @@ async function runGatewayServiceCommand(
 }
 
 /**
- * GET /api/gateway - Returns comprehensive gateway health status.
- *
- * Uses `runCliJson(["health"])` which is routed through the unified
- * OpenClawClient (AutoTransport by default). AutoTransport probes the
- * Gateway over HTTP first and falls back to CLI — so this works in
- * Docker (where the CLI binary is slow) and on Mac (where CLI is fast).
- *
- * Timeout bumped to 30s for environments with cold CLI starts.
+ * Quick gateway liveness check — just probe the HTTP endpoint.
+ * This avoids the slow `openclaw health --json` CLI which loads all
+ * plugins and takes 15-20s (often exceeding the frontend's 15s abort).
  */
-export async function GET() {
+async function probeGatewayHttp(): Promise<{
+  ok: boolean;
+  port: number;
+  url: string;
+}> {
+  const url = await getGatewayUrl();
+  const port = parseInt(new URL(url).port, 10) || 18789;
   try {
-    const health = await runCliJson<Record<string, unknown>>(
-      ["health"],
-      30000
-    );
-    // Validate the response has the expected shape — a malformed or empty
-    // response should not silently report "degraded".
-    if (!health || typeof health !== "object") {
-      return NextResponse.json({
-        status: "offline",
-        health: { ok: false, error: "Unexpected health check response" },
-      });
-    }
-    return NextResponse.json({
-      status: health.ok ? "online" : "degraded",
-      health,
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(3000),
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    const isTimeout =
-      message.includes("timed out") ||
-      message.includes("TIMEOUT") ||
-      message.includes("aborted");
-    return NextResponse.json({
-      status: "offline",
-      health: {
-        ok: false,
-        error: isTimeout
-          ? "Gateway health check timed out"
-          : "Gateway is not running",
-      },
-    });
+    return { ok: res.ok, port, url };
+  } catch {
+    return { ok: false, port, url };
   }
 }
 
 /**
- * POST /api/gateway - Restart/stop the gateway.
- * Body: { action: "restart" | "stop" }
+ * GET /api/gateway - Returns gateway health status.
  *
- * For restart: sends SIGTERM to the gateway process, then the macOS app
- * or daemon manager automatically restarts it.
+ * Strategy:
+ *   1. Quick HTTP probe to the gateway (< 3s) for liveness.
+ *   2. If alive, run `openclaw health --json` via direct CLI spawn
+ *      (not through auto-transport which re-routes through the gateway).
+ *   3. Return online/offline based on the probe; include full health
+ *      data when the CLI completes in time.
  */
+export async function GET() {
+  // Fast liveness check first
+  const probe = await probeGatewayHttp();
+
+  if (!probe.ok) {
+    return NextResponse.json({
+      status: "offline",
+      health: { ok: false, error: "Gateway HTTP endpoint not reachable" },
+    });
+  }
+
+  // Gateway is alive — try to get full health data via CLI (directly,
+  // bypassing auto-transport to avoid the recursive exec-through-gateway issue).
+  try {
+    const bin = await getOpenClawBin();
+    const { stdout } = await exec(bin, ["health", "--json"], {
+      timeout: 25000,
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+    // Parse JSON from stdout (may have non-JSON prefix lines from plugin loading)
+    const jsonStart = stdout.indexOf("{");
+    if (jsonStart >= 0) {
+      const health = JSON.parse(stdout.slice(jsonStart));
+      return NextResponse.json({
+        status: health.ok ? "online" : "degraded",
+        health,
+      });
+    }
+  } catch {
+    // CLI timed out or failed — but gateway IS reachable via HTTP
+  }
+
+  // Gateway is reachable but full health data unavailable — report online
+  return NextResponse.json({
+    status: "online",
+    health: { ok: true, port: probe.port, note: "Lite probe (full health unavailable)" },
+  });
+}
 export async function POST(req: Request) {
   try {
     const body = await req.json();


### PR DESCRIPTION
## Symptom

In the Mission Control dashboard header and `/tasks` page, the gateway status indicator always showed **Offline** even when the gateway was fully running and chat was working normally through it. Restarting did not fix it.

## Root Cause

The `GET /api/gateway` endpoint called `runCliJson(["health"])` via `AutoTransport`. AutoTransport probes the gateway over HTTP first, then routes CLI commands through the gateway's own RPC exec tool — meaning `openclaw health --json` was being executed *inside* the gateway as a subprocess of itself.

This created a circular dependency: the health check spawned a new `openclaw` process that took 15-20s to load all plugins, and the frontend's `AbortSignal.timeout(15000)` killed the request before it could resolve. Every poll timed out → status permanently **offline**.

## Fix

- Replace the `runCliJson(["health"])` call with a direct HTTP probe to the gateway endpoint (< 3s) for liveness detection
- If alive, attempt `openclaw health --json` via direct `execFile` (bypassing AutoTransport entirely) for full health data  
- If the CLI times out but the HTTP probe succeeded, still report online
- Add `turbopack: {}` to `next.config.ts` to silence Next.js 16 Turbopack migration warning during build

## Changes

- `src/app/api/gateway/route.ts` — replace health check logic
- `next.config.ts` — add `turbopack: {}`