### PR TITLE
Use CLI channels add instead of config.patch RPC for channel connect

### DIFF
--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readFile } from "fs/promises";
 import { join } from "path";
-import { gatewayCall } from "@/lib/openclaw";
+import { gatewayCall, runCli } from "@/lib/openclaw";
 import { patchConfig } from "@/lib/gateway-config";
 import { getOpenClawHome } from "@/lib/paths";
 
@@ -182,25 +182,32 @@ export async function POST(request: NextRequest) {
           return NextResponse.json({ ok: true, message: "WhatsApp enabled. Use QR login to link your phone." });
         }
 
-        // Telegram / Discord: save token via config patch.
-        // groupPolicy defaults to "mention" so the bot responds when mentioned
-        // in groups. Without this, the gateway defaults to "allowlist" with an
-        // empty allowFrom list, silently dropping all group messages.
-        const patch: Record<string, unknown> = {
-          enabled: true,
-          dmPolicy: (body.dmPolicy as string) || "pairing",
-          groupPolicy: (body.groupPolicy as string) || "mention",
-        };
-        if (channel === "telegram") patch.botToken = token;
-        else if (channel === "discord") patch.token = token;
-        else patch.botToken = token;
-
-        await patchConfig(
-          { channels: { [channel]: patch } },
-          { restartDelayMs: 2000 },
+        // Use the CLI `channels add` — it writes config to disk directly
+        // without needing the gateway RPC. This avoids the
+        // config.patch → gateway-self-restart → poll-until-alive dance
+        // that caused timeout errors during onboarding.
+        await runCli(
+          ["channels", "add", "--channel", channel, "--token", token],
+          15000,
         );
 
-        return NextResponse.json({ ok: true, message: `${channel} connected. Gateway is restarting.` });
+        // The CLI defaults groupPolicy to "allowlist" with an empty
+        // allowFrom list which silently drops all group messages.
+        // Patch the policies to sensible defaults for onboarding.
+        try {
+          await patchConfig({
+            channels: {
+              [channel]: {
+                dmPolicy: (body.dmPolicy as string) || "pairing",
+                groupPolicy: (body.groupPolicy as string) || "mention",
+              },
+            },
+          });
+        } catch {
+          // non-fatal — policies can be adjusted later from the dashboard
+        }
+
+        return NextResponse.json({ ok: true, message: `${channel} connected.` });
       }
 
       /* ── Disconnect (remove channel) ── */

--- a/src/components/onboarding-wizard.tsx
+++ b/src/components/onboarding-wizard.tsx
@@ -657,7 +657,7 @@ export function OnboardingWizard({ onComplete }: { onComplete?: () => void }) {
 
       if (abort.signal.aborted) return;
 
-      // Phase 2: Save config
+      // Phase 2: Save config via CLI (writes to disk, no gateway restart dance)
       setConnectPhase("saving");
       const res = await fetch("/api/channels", {
         method: "POST",
@@ -676,14 +676,6 @@ export function OnboardingWizard({ onComplete }: { onComplete?: () => void }) {
       }
 
       if (abort.signal.aborted) return;
-
-      // Phase 3: Wait for gateway restart and channel readiness
-      setConnectPhase("restarting");
-      const healthy = await waitForGatewayHealth(currentChannel.id);
-      if (abort.signal.aborted) return;
-      if (!healthy) {
-        throw new Error("Connection is taking a while — please try again. If it keeps failing, check that your token is correct.");
-      }
 
       setConnectPhase("ready");
       setChannelResult({
@@ -709,7 +701,7 @@ export function OnboardingWizard({ onComplete }: { onComplete?: () => void }) {
       if (!abort.signal.aborted) setChannelBusy(false);
       connectAbortRef.current = null;
     }
-  }, [channelAppToken, channelToken, currentChannel, waitForGatewayHealth]);
+  }, [channelAppToken, channelToken, currentChannel]);
 
   const handleApprovePairing = useCallback(async (request: PairingRequest) => {
     // Idempotency guard: skip if already approved or in-flight


### PR DESCRIPTION
The channel connect flow was: config.patch (RPC) → gateway self-restart → poll health 30× over 60s waiting for it to come back. This caused timeout errors during onboarding because the gateway kills its own RPC connection when restarting, and channel init (especially Telegram) can be slow.

Now uses `openclaw channels add` CLI which writes config to disk directly without needing a running gateway. The frontend no longer polls for gateway restart — it shows success as soon as config is saved. The gateway picks up the new config on its next restart.

Also patches dmPolicy/groupPolicy to "pairing"/"mention" defaults since the CLI defaults groupPolicy to "allowlist" with an empty allowFrom, which silently drops all group messages.

https://claude.ai/code/session_01LfFxmCeQowaeHFqSWigsMC