### PR TITLE
chore(audit): automated npm audit fix --force (branch mission-control/audit-fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/dashboard",
-  "version": "0.4.0",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/dashboard",
-      "version": "0.4.0",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/react": "^3.0.88",
@@ -3689,13 +3689,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4151,9 +4151,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6020,7 +6020,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8359,9 +8358,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
Title: chore(audit): automated npm audit fix --force (branch mission-control/audit-fix)

Summary
- Ran npm audit fix --force in a dedicated branch (mission-control/audit-fix) to remediate known vulnerabilities.
- Aggressive fixes resolved the high-severity minimatch ReDoS. Remaining advisories: dompurify (moderate) and monaco-editor (transitive via dompurify). These remain to be fixed via targeted upgrades/testing.

What I changed
- package.json / package-lock.json updates committed in branch mission-control/audit-fix.

What I tested
- Dev server started locally with NEXT_TELEMETRY_DISABLED=1.
- Ran a memory graph bootstrap with a dummy OPENAI_API_KEY; endpoint returned graph and handled the dummy key gracefully.
- Verified credential files exist at $HOME/.openclaw/openclaw.json and $HOME/.openclaw/agents/main/agent/auth-profiles.json and currently have 600 perms.

Next steps (recommended)
1) Review the package changes and run CI/e2e tests (Playwright) against this branch.
2) Resolve remaining dompurify/monaco transitive advisory (likely requires a monaco upgrade or vendor patch).
3) If tests pass, merge the branch; otherwise revert or surgically update specific packages.
4) Add setup guard: run npm audit in setup and warn/abort on critical vulnerabilities.

Attached
- mission-control-audit-fix.bundle (git bundle of branch)
- mission-control-audit-fix.diff (diff vs origin/main)

PR</cat>

echo "Created bundle and PR draft at /Users/dangrossman/clawd/tmp/"
