### PR TITLE
ci: add lint, typecheck, and build verification on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  push:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint · Typecheck · Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` with:

- **Lint** — `npm run lint` (ESLint with Next.js + TypeScript config)
- **Typecheck** — `npx tsc --noEmit` (strict mode)
- **Build** — `npm run build` (Next.js production build)

Runs on pull_request and push to main/master. Concurrency group cancels in-progress runs for the same PR. 15-minute timeout.

Note: Current codebase has 9 pre-existing lint errors and 34 warnings (ESLint exits 0). These are visible in CI output but don't block the build. Can tighten with `--max-warnings 0` once the existing issues are cleaned up.

Part of CI rollout across all active repos.