### PR TITLE
docs: add Krasyn/Ben's-Mac quickstart for Mission Control

### DIFF
--- a/KRASYN-SETUP.md
+++ b/KRASYN-SETUP.md
@@ -7,7 +7,7 @@ Ben-specific setup notes layered on top of the upstream `README.md`. Everything 
 - OpenClaw is installed at `~/.openclaw` (29 MB, 3 agents: `main`/`claude-cli`/`claude-code`).
 - Gateway is running on `127.0.0.1:18789` (token auth, loopback bind).
 - Gateway token lives in `~/.openclaw/openclaw.json` under `gateway.auth.token`. Mission Control auto-reads it — you should not have to paste it anywhere.
-- Primary model `ollama/qwen3:14b`, fallback `openai/gpt-5.4`. Ollama is expected at `127.0.0.1:11434`.
+- Primary model `openai/gpt-5.4` (orchestrator). Sub-agents: `qwen` (ollama/qwen3:14b), `gemma` (ollama/gemma4, still downloading). Fallbacks on GPT-5.4 failure: gpt-5.4-mini → qwen3:14b. Ollama at `127.0.0.1:11434`.
 - Agent `main` (Em) is Telegram-fronting; the bot token is configured.
 
 If `openclaw gateway status` shows `offline`, run `openclaw gateway start` first. Check with:
@@ -40,24 +40,39 @@ cd openclaw-mission-control
 Open `http://127.0.0.1:3000` and verify:
 
 1. **Dashboard** — gateway indicator green, 3 agents listed (`main`, `claude-cli`, `claude-code`), Ollama reachable.
-2. **Agents** — org chart renders. Em (`main`) sits at the top, claude-cli and claude-code appear as siblings. Click a node → agent details + "Start / Stop" controls.
+2. **Agents** — org chart renders. Em (`main`, GPT-5.4) is marked "Orchestrator". `qwen` and `gemma` appear as "Sub-agent" nodes with animated "invokes" edges from Em. Click a node → agent details.
 3. **Tasks** — empty Kanban (Backlog / In Progress / Review / Done). Try creating a card; it should land as a file in `~/.openclaw/workspace`.
 4. **Memory** — `MEMORY.md` (Ben's long-term memory) loads. Daily notes directory is at `~/.openclaw/workspace/memory/` (created on first write).
 5. **Channels** — Telegram shows "connected" for agent `main`. No re-pairing needed.
 6. **Cron** — empty list. Heartbeat is running inside the gateway process.
 7. **Doctor** — run it once. Expect all green except possibly Tailscale (off by default in `openclaw.json`).
 
-## Expected agent hierarchy (the "org chart")
-
-Given the current `~/.openclaw/agents/` layout:
+## Agent architecture (orchestrator + sub-agents)
 
 ```
-Em (main)            ← orchestrator, Telegram front-door
-  ├── claude-cli     ← worker (Claude via CLI)
-  └── claude-code    ← worker (Claude Code; owns the Krasyn repo)
+User (Telegram / Mission Control chat)
+  └── Em (main) — openai/gpt-5.4  ← orchestrator, Telegram front-door
+        ├── qwen  — ollama/qwen3:14b   ← local heavy lifting (coding, long context)
+        └── gemma — ollama/gemma4      ← local fast tasks (gemma4 pulling ~9.6 GB)
 ```
 
-Add more workers by dropping a new agent folder under `~/.openclaw/agents/<name>/` with its own `openclaw.json`. Mission Control will pick it up on next refresh.
+**How routing works:**
+- All user messages go to Em (GPT-5.4). Em is the primary model and the only agent exposed to channels.
+- GPT-5.4 invokes `qwen` or `gemma` via the OpenClaw `agent_to_agent` tool when it wants a local model to do the heavy lifting — e.g. processing long documents, running code-heavy analysis. This is tool-call delegation, not automatic fallback.
+- Fallback (on GPT-5.4 API error only): `openai/gpt-5.4-mini`, then `ollama/qwen3:14b`.
+- `qwen` and `gemma` are **not** directly chat-accessible by default. They show as sub-agents in the Mission Control hierarchy view.
+
+**Claude Code integration (pending):**
+The `claude-cli` and `claude-code` directories under `~/.openclaw/agents/` are stubs created during setup. Full integration requires the `claude` CLI (`npm install -g @anthropic-ai/claude-code` or via brew). Once installed, add a `claude-code` agent with `openclaw agents add claude-code --model claude-code-backend` and wire it into Em's allowed sub-agents.
+
+**Adding more sub-agents:**
+```bash
+openclaw agents add <name> --model <provider/model> --workspace ~/.openclaw/agents/<name>/workspace --non-interactive
+# Then allow Em to invoke it:
+openclaw config set tools.agentToAgent.allow '["qwen","gemma","<name>"]' --strict-json
+# And update main's subagents allowlist:
+openclaw config set agents.list ... (see config schema)
+```
 
 ## Known gotchas on this Mac
 

--- a/KRASYN-SETUP.md
+++ b/KRASYN-SETUP.md
@@ -1,0 +1,82 @@
+# Mission Control — Krasyn / Ben's Mac quickstart
+
+Ben-specific setup notes layered on top of the upstream `README.md`. Everything here is machine-specific to this install; keep it out of any upstream PR.
+
+## Pre-flight check (already true on this Mac)
+
+- OpenClaw is installed at `~/.openclaw` (29 MB, 3 agents: `main`/`claude-cli`/`claude-code`).
+- Gateway is running on `127.0.0.1:18789` (token auth, loopback bind).
+- Gateway token lives in `~/.openclaw/openclaw.json` under `gateway.auth.token`. Mission Control auto-reads it — you should not have to paste it anywhere.
+- Primary model `ollama/qwen3:14b`, fallback `openai/gpt-5.4`. Ollama is expected at `127.0.0.1:11434`.
+- Agent `main` (Em) is Telegram-fronting; the bot token is configured.
+
+If `openclaw gateway status` shows `offline`, run `openclaw gateway start` first. Check with:
+
+```bash
+openclaw --version
+openclaw gateway status
+lsof -iTCP:18789 -sTCP:LISTEN
+```
+
+## Install
+
+```bash
+# Clone (or use the working copy already staged in outputs)
+cd ~/Projects 2>/dev/null || (mkdir -p ~/Projects && cd ~/Projects)
+git clone https://github.com/robsannaa/openclaw-mission-control.git
+cd openclaw-mission-control
+
+# One-shot setup (installs deps + starts dashboard in background)
+./setup.sh
+
+# Or, dev mode (foreground, no background service)
+./setup.sh --dev --no-service
+```
+
+**Port:** this fork defaults to `127.0.0.1:3000` (from `package.json` → `dev` script `next dev -H 127.0.0.1 -p 3000`), not `3333` as the upstream README shows. Override with `PORT=8080 ./setup.sh` if 3000 is taken.
+
+## First-open checks
+
+Open `http://127.0.0.1:3000` and verify:
+
+1. **Dashboard** — gateway indicator green, 3 agents listed (`main`, `claude-cli`, `claude-code`), Ollama reachable.
+2. **Agents** — org chart renders. Em (`main`) sits at the top, claude-cli and claude-code appear as siblings. Click a node → agent details + "Start / Stop" controls.
+3. **Tasks** — empty Kanban (Backlog / In Progress / Review / Done). Try creating a card; it should land as a file in `~/.openclaw/workspace`.
+4. **Memory** — `MEMORY.md` (Ben's long-term memory) loads. Daily notes directory is at `~/.openclaw/workspace/memory/` (created on first write).
+5. **Channels** — Telegram shows "connected" for agent `main`. No re-pairing needed.
+6. **Cron** — empty list. Heartbeat is running inside the gateway process.
+7. **Doctor** — run it once. Expect all green except possibly Tailscale (off by default in `openclaw.json`).
+
+## Expected agent hierarchy (the "org chart")
+
+Given the current `~/.openclaw/agents/` layout:
+
+```
+Em (main)            ← orchestrator, Telegram front-door
+  ├── claude-cli     ← worker (Claude via CLI)
+  └── claude-code    ← worker (Claude Code; owns the Krasyn repo)
+```
+
+Add more workers by dropping a new agent folder under `~/.openclaw/agents/<name>/` with its own `openclaw.json`. Mission Control will pick it up on next refresh.
+
+## Known gotchas on this Mac
+
+- `~/.openclaw` has macOS extended-attribute protection (ACLs, the `+` in `ls -la`). Don't try to `git clone` directly into it from a Linux shell — the clone will fail to unlink `.git/config.lock`. Clone into `~/Projects` instead (this doc) and let Mission Control read the OpenClaw state via the gateway.
+- Gateway log path is `/tmp/openclaw/openclaw-YYYY-MM-DD.log` (see `~/.openclaw/logs/gateway.log`). Mission Control's Logs view auto-discovers this.
+- Em's auto-compaction kicks in when Telegram conversations grow past the qwen3 40k-token window — expect occasional "auto-compaction succeeded; retrying prompt" entries; harmless.
+- `controlUi.allowInsecureAuth` is `true` in the current config, meaning the browser sends the bearer token over plain HTTP on localhost. Fine for loopback; don't expose the port beyond 127.0.0.1.
+
+## Remote access (optional)
+
+`openclaw.json` has `tailscale.mode: off`. To reach the dashboard from another machine:
+
+```bash
+# Simple SSH tunnel
+ssh -N -L 3000:127.0.0.1:3000 krasyn@<this-mac-ip>
+```
+
+Or flip Tailscale on in `openclaw.json` (`gateway.tailscale.mode: "on"`) and follow the onboarding.
+
+## Security note
+
+Do **not** commit `~/.openclaw/openclaw.json` or any derivative into this repo or a PR. It contains the gateway bearer token and the Telegram bot token. Mission Control reads these live from disk; they should never be checked in.

--- a/KRASYN-SETUP.md
+++ b/KRASYN-SETUP.md
@@ -58,20 +58,24 @@ User (Telegram / Mission Control chat)
 
 **How routing works:**
 - All user messages go to Em (GPT-5.4). Em is the primary model and the only agent exposed to channels.
-- GPT-5.4 invokes `qwen` or `gemma` via the OpenClaw `agent_to_agent` tool when it wants a local model to do the heavy lifting — e.g. processing long documents, running code-heavy analysis. This is tool-call delegation, not automatic fallback.
+- Em invokes sub-agents via the OpenClaw `sessions_spawn` tool. Use `agents_list` to enumerate available targets.
 - Fallback (on GPT-5.4 API error only): `openai/gpt-5.4-mini`, then `ollama/qwen3:14b`.
-- `qwen` and `gemma` are **not** directly chat-accessible by default. They show as sub-agents in the Mission Control hierarchy view.
+- `qwen`, `gemma`, and `claude-code` are not directly chat-accessible. They appear as sub-agents in the Mission Control hierarchy view.
 
-**Claude Code integration (pending):**
-The `claude-cli` and `claude-code` directories under `~/.openclaw/agents/` are stubs created during setup. Full integration requires the `claude` CLI (`npm install -g @anthropic-ai/claude-code` or via brew). Once installed, add a `claude-code` agent with `openclaw agents add claude-code --model claude-code-backend` and wire it into Em's allowed sub-agents.
+**Claude Code integration (active):**
+`claude` CLI at `/opt/homebrew/bin/claude` (v2.1.114). `claude-code` agent registered in `agents.list` and in `main.subagents.allowAgents`. Em can invoke it via `sessions_spawn(agentId="claude-code", ...)`.
+
+**Critical workspace file — `~/.openclaw/workspace/AGENTS.md`:**
+This file is injected at every session startup. It MUST describe Em's role and sub-agents accurately. The `## Session Startup` and `## Red Lines` sections are re-injected after context compaction. If Em claims it can't find sub-agents, check this file first — bad content here will override Em's understanding of its own capabilities.
 
 **Adding more sub-agents:**
 ```bash
 openclaw agents add <name> --model <provider/model> --workspace ~/.openclaw/agents/<name>/workspace --non-interactive
-# Then allow Em to invoke it:
-openclaw config set tools.agentToAgent.allow '["qwen","gemma","<name>"]' --strict-json
-# And update main's subagents allowlist:
-openclaw config set agents.list ... (see config schema)
+# Allow Em to spawn it:
+openclaw config set agents.list[0].subagents.allowAgents '["qwen","gemma","claude-code","<name>"]' --strict-json
+# Also update cross-agent session access:
+openclaw config set tools.agentToAgent.allow '["qwen","gemma","claude-code","<name>"]' --strict-json
+# Then add a description to ~/.openclaw/workspace/AGENTS.md so Em knows when to use it.
 ```
 
 ## Known gotchas on this Mac

--- a/src/app/api/chat/last-response/route.ts
+++ b/src/app/api/chat/last-response/route.ts
@@ -1,0 +1,94 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import os from "os";
+
+type SessionRecord = {
+  sessionFile?: string;
+};
+
+type MessageEvent = {
+  type: string;
+  message?: {
+    role: string;
+    content: unknown;
+  };
+};
+
+type ContentPart = {
+  type: string;
+  text?: string;
+};
+
+/**
+ * GET /api/chat/last-response?agentId=<id>&sessionKey=<key>
+ *
+ * Reads the gateway's JSONL session file for the given session key and
+ * returns the last non-empty assistant message text. Used by the chat UI
+ * to recover a completed response after the SSE stream was dropped (e.g.
+ * when the browser backgrounded the tab mid-stream).
+ *
+ * Returns: { text: string }  or 404 if no complete response is found.
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const agentId = url.searchParams.get("agentId") || "main";
+  const sessionKey = url.searchParams.get("sessionKey");
+
+  if (!sessionKey) {
+    return new Response("missing sessionKey", { status: 400 });
+  }
+
+  try {
+    const sessionsPath = path.join(
+      os.homedir(),
+      ".openclaw",
+      "agents",
+      agentId,
+      "sessions",
+      "sessions.json",
+    );
+
+    const sessionsRaw = await readFile(sessionsPath, "utf-8");
+    const sessions = JSON.parse(sessionsRaw) as Record<string, SessionRecord>;
+    const session = sessions[sessionKey];
+
+    if (!session?.sessionFile) {
+      return new Response("session not found", { status: 404 });
+    }
+
+    const jsonlRaw = await readFile(session.sessionFile, "utf-8");
+    const lines = jsonlRaw.split("\n").filter(Boolean);
+
+    // Walk backwards — the last assistant message with actual text wins.
+    for (let i = lines.length - 1; i >= 0; i--) {
+      let event: MessageEvent;
+      try {
+        event = JSON.parse(lines[i]) as MessageEvent;
+      } catch {
+        continue;
+      }
+
+      if (event.type !== "message" || event.message?.role !== "assistant") continue;
+
+      const content = event.message.content;
+      let text = "";
+
+      if (Array.isArray(content)) {
+        text = (content as ContentPart[])
+          .filter((p) => p.type === "text" || p.type === "output_text")
+          .map((p) => p.text ?? "")
+          .join("");
+      } else if (typeof content === "string") {
+        text = content;
+      }
+
+      if (text.trim()) {
+        return Response.json({ text: text.trim() });
+      }
+    }
+
+    return new Response("no response found", { status: 404 });
+  } catch {
+    return new Response("error reading session", { status: 500 });
+  }
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -68,7 +68,8 @@ function buildUserTurnItems(msg: Message): { textParts: string[]; fileParts: str
         fileParts.push(dataUrlToSafeMessagePart(p.url, name));
         const mime = p.mimeType || guessMime(p.url, p.filename);
         if (mime.startsWith("image/")) {
-          orContent.push({ type: "input_image", source: { type: "url", url: p.url } });
+          // OpenAI Responses API: image_url is a plain string (data URL or https URL)
+          orContent.push({ type: "input_image", image_url: p.url });
         } else {
           const base64Match = p.url.match(/^data:[^;]+;base64,(.+)$/);
           if (base64Match) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -68,7 +68,7 @@ function buildUserTurnItems(msg: Message): { textParts: string[]; fileParts: str
         fileParts.push(dataUrlToSafeMessagePart(p.url, name));
         const mime = p.mimeType || guessMime(p.url, p.filename);
         if (mime.startsWith("image/")) {
-          orContent.push({ type: "image_url", image_url: { url: p.url } });
+          orContent.push({ type: "input_image", source: { type: "url", url: p.url } });
         } else {
           const base64Match = p.url.match(/^data:[^;]+;base64,(.+)$/);
           if (base64Match) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -322,6 +322,87 @@ type SubagentSessionRecord = {
   sessionFile?: string;
 };
 
+/**
+ * Scan all sub-agent directories for a session started during this request.
+ * sessions_spawn is handled internally by the gateway and never appears in
+ * the SSE stream, so we must scan after the orchestrator stream ends.
+ *
+ * Strategy:
+ *  - Check immediately: by the time Em's stream ends, the sub-agent is
+ *    typically already created (the spawn happens mid-run).
+ *  - If found but still running, poll up to 90s for completion.
+ *  - If not found on first pass, wait 3s and try once more, then bail.
+ *    (Avoids a long scan on requests with no delegation.)
+ */
+async function findAnySubagentResult(
+  orchAgentId: string,
+  requestStartTime: number,
+): Promise<{ agentId: string; text: string } | null> {
+  const agentsDir = path.join(getOpenClawHome(), "agents");
+  let agentIds: string[];
+  try {
+    agentIds = fs
+      .readdirSync(agentsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name !== orchAgentId)
+      .map((e) => e.name);
+  } catch {
+    return null;
+  }
+  if (agentIds.length === 0) return null;
+
+  const scanForSession = (): { id: string; sessionFile: string; done: boolean } | null => {
+    for (const id of agentIds) {
+      const p = path.join(agentsDir, id, "sessions", "sessions.json");
+      try {
+        const raw = fs.readFileSync(p, "utf-8");
+        const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
+        const candidates = Object.values(sessions)
+          .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile)
+          .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
+        if (candidates[0]) {
+          return { id, sessionFile: candidates[0].sessionFile!, done: !!candidates[0].endedAt };
+        }
+      } catch { /* not readable */ }
+    }
+    return null;
+  };
+
+  // First immediate scan — sub-agent is usually already created by now.
+  let found = scanForSession();
+
+  // If not found, give it one more short window (3s) then bail.
+  if (!found) {
+    await delay(3000);
+    found = scanForSession();
+    if (!found) return null;
+  }
+
+  // Sub-agent was found. If already done, return immediately.
+  if (found.done) {
+    const text = readSubagentSessionText(found.sessionFile);
+    if (text) return { agentId: found.id, text };
+  }
+
+  // Otherwise poll up to 90s for completion.
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    await delay(2000);
+    const p = path.join(agentsDir, found.id, "sessions", "sessions.json");
+    try {
+      const raw = fs.readFileSync(p, "utf-8");
+      const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
+      const candidates = Object.values(sessions)
+        .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile && s.endedAt)
+        .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
+      if (candidates[0]?.sessionFile) {
+        const text = readSubagentSessionText(candidates[0].sessionFile);
+        if (text) return { agentId: found.id, text };
+      }
+    } catch { /* not readable */ }
+  }
+  return null;
+}
+
 
 /**
  * Poll ~/.openclaw/agents/{agentId}/sessions/sessions.json until a session
@@ -387,18 +468,18 @@ function readSubagentSessionText(sessionFile: string): string | null {
 
 
 /**
- * After Em's first stream completes and sessions_spawn was detected in the
- * stream, poll for the sub-agent result then fire a second Em turn and pipe
- * its response into the already-open stream controller.
+ * After Em's first stream completes, poll for a sub-agent result then fire a
+ * second Em turn and pipe its response into the already-open stream controller.
  *
- * If spawnedAgentId is null (no sessions_spawn detected), returns immediately
- * — avoids a 10 s scan on every non-delegation request.
+ * sessions_spawn is handled internally by the gateway (not exposed in SSE),
+ * so we always scan sub-agent directories after the orchestrator stream ends.
+ * The scan is fast: sub-agent sessions are typically already created by then.
  */
 async function autoRelaySubagentResult(
   ctrl: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
   opts: {
-    spawnedAgentId: string | null;
+    spawnedAgentId: string | null; // from SSE stream if available (otherwise null)
     requestStartTime: number;
     orchAgentId: string;
     sessionKey: string | undefined;
@@ -407,16 +488,23 @@ async function autoRelaySubagentResult(
     gwHeaders: Record<string, string>;
   },
 ): Promise<void> {
-  const { spawnedAgentId, requestStartTime, sessionKey, gwUrl, token, gwHeaders } = opts;
+  const { spawnedAgentId, requestStartTime, orchAgentId, sessionKey, gwUrl, token, gwHeaders } = opts;
 
-  // Only relay when sessions_spawn was explicitly detected in the stream.
-  if (!spawnedAgentId) return;
+  let result: string | null = null;
+  let resolvedAgentId = spawnedAgentId ?? "sub-agent";
 
-  const result = await pollForSubagentResult(spawnedAgentId, requestStartTime);
+  if (spawnedAgentId) {
+    result = await pollForSubagentResult(spawnedAgentId, requestStartTime);
+  } else {
+    // sessions_spawn doesn't appear in the SSE stream — scan all sub-agent dirs.
+    const found = await findAnySubagentResult(orchAgentId, requestStartTime);
+    if (found) { result = found.text; resolvedAgentId = found.agentId; }
+  }
+
   if (!result) return;
 
   // Fire a second orchestrator turn with the sub-agent result
-  const continuationInput = `[Subagent ${spawnedAgentId} completed its task. Result: "${result}" — please relay this to the user now.]`;
+  const continuationInput = `[Subagent ${resolvedAgentId} completed its task. Result: "${result}" — please relay this to the user now.]`;
 
   const headers: Record<string, string> = { ...gwHeaders, "Content-Type": "application/json" };
   if (sessionKey) headers["x-openclaw-session-key"] = sessionKey;
@@ -429,7 +517,7 @@ async function autoRelaySubagentResult(
       method: "POST",
       headers,
       body: JSON.stringify({
-        model: `openclaw:${opts.orchAgentId}`,
+        model: `openclaw:${orchAgentId}`,
         input: continuationInput,
         stream: true,
       }),

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -53,53 +53,88 @@ function normalizeRequestedSessionKey(raw: unknown): string | undefined {
 }
 
 
+function buildUserTurnItems(msg: Message): { textParts: string[]; fileParts: string[]; orContent: unknown[] } {
+  const textParts: string[] = [];
+  const fileParts: string[] = [];
+  const orContent: unknown[] = [];
+
+  if (msg.parts) {
+    for (const p of msg.parts) {
+      if (p.type === "text" && p.text) {
+        textParts.push(p.text);
+        orContent.push({ type: "text", text: p.text });
+      } else if (p.type === "file" && p.url) {
+        const name = (p.filename || "file").replace(/\s+/g, " ");
+        fileParts.push(dataUrlToSafeMessagePart(p.url, name));
+        const mime = p.mimeType || guessMime(p.url, p.filename);
+        if (mime.startsWith("image/")) {
+          orContent.push({ type: "image_url", image_url: { url: p.url } });
+        } else {
+          const base64Match = p.url.match(/^data:[^;]+;base64,(.+)$/);
+          if (base64Match) {
+            orContent.push({ type: "text", text: `[Attached file: ${name}]` });
+          }
+        }
+      }
+    }
+  } else if (msg.content) {
+    textParts.push(msg.content);
+    orContent.push({ type: "text", text: msg.content });
+  }
+
+  return { textParts, fileParts, orContent };
+}
+
 function extractContent(messages: Message[]): {
   plainText: string;
   openResponsesInput: unknown;
 } {
   const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
-  const textParts: string[] = [];
-  const fileParts: string[] = [];
-  const orItems: unknown[] = [];
 
-  if (lastUserMsg?.parts) {
-    for (const p of lastUserMsg.parts) {
-      if (p.type === "text" && p.text) {
-        textParts.push(p.text);
-        orItems.push({ type: "message", role: "user", content: p.text });
-      } else if (p.type === "file" && p.url) {
-        const name = (p.filename || "file").replace(/\s+/g, " ");
-        fileParts.push(dataUrlToSafeMessagePart(p.url, name));
-
-        // Build native OpenResponses input items for files
-        const mime = p.mimeType || guessMime(p.url, p.filename);
-        if (mime.startsWith("image/")) {
-          orItems.push({ type: "input_image", source: { type: "url", url: p.url } });
-        } else {
-          const base64Match = p.url.match(/^data:[^;]+;base64,(.+)$/);
-          if (base64Match) {
-            orItems.push({
-              type: "input_file",
-              source: { type: "base64", media_type: mime, data: base64Match[1], filename: name },
-            });
-          }
-        }
-      }
-    }
-  } else if (lastUserMsg?.content) {
-    textParts.push(lastUserMsg.content);
-    orItems.push({ type: "message", role: "user", content: lastUserMsg.content });
-  }
-
-  const textBlock = textParts.join("").trim();
-  const fileBlock = fileParts.length ? "\n\n" + fileParts.join("\n\n---\n\n") : "";
+  // plainText is always derived from the last user message (for empty-check)
+  const lastTurn = lastUserMsg ? buildUserTurnItems(lastUserMsg) : { textParts: [], fileParts: [], orContent: [] };
+  const textBlock = lastTurn.textParts.join("").trim();
+  const fileBlock = lastTurn.fileParts.length ? "\n\n" + lastTurn.fileParts.join("\n\n---\n\n") : "";
   const plainText = (textBlock + fileBlock).trim();
 
-  // Flatten simple text-only to a plain string
+  // For multi-turn conversations, build the full history so the model has context
+  // even when the gateway session is cold (e.g. first load or after clearChat).
+  const conversationTurns = messages.filter(
+    (m) => m.role === "user" || m.role === "assistant"
+  );
+
+  const orItems: unknown[] = [];
+  for (const msg of conversationTurns) {
+    if (msg.role === "assistant") {
+      const text =
+        msg.parts
+          ?.filter((p) => p.type === "text")
+          .map((p) => p.text ?? "")
+          .join("") || msg.content || "";
+      if (text.trim()) {
+        orItems.push({ type: "message", role: "assistant", content: text.trim() });
+      }
+      continue;
+    }
+    // user turn
+    const { orContent } = buildUserTurnItems(msg);
+    if (orContent.length === 0) continue;
+    const content =
+      orContent.length === 1 && (orContent[0] as { type: string }).type === "text"
+        ? (orContent[0] as { type: string; text: string }).text
+        : orContent;
+    orItems.push({ type: "message", role: "user", content });
+  }
+
+  // Single text-only turn → plain string (gateway accepts both forms)
   const openResponsesInput =
-    orItems.length === 1 && (orItems[0] as { type: string }).type === "message"
+    orItems.length === 1 &&
+    (orItems[0] as { type: string; role: string; content: unknown }).role === "user" &&
+    typeof (orItems[0] as { content: unknown }).content === "string"
       ? (orItems[0] as { content: string }).content
-      : orItems;
+      : orItems.length > 0
+        ? orItems
+        : plainText;
 
   return { plainText, openResponsesInput };
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -294,6 +294,21 @@ type SubagentSessionRecord = {
 };
 
 /**
+ * Return the list of sub-agent IDs to scan (all agent dirs except the orchestrator).
+ */
+function listSubagentIds(orchAgentId: string): string[] {
+  try {
+    const agentsDir = path.join(getOpenClawHome(), "agents");
+    return fs
+      .readdirSync(agentsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name !== orchAgentId)
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Poll ~/.openclaw/agents/{agentId}/sessions/sessions.json until a session
  * started after `requestStartTime` finishes, then return its final assistant
  * message text.  Returns null on timeout.
@@ -317,39 +332,100 @@ async function pollForSubagentResult(
     try {
       const raw = fs.readFileSync(sessionsJsonPath, "utf-8");
       const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
-
-      // Find completed sub-agent sessions started after our request began
       const candidates = Object.values(sessions)
         .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile && s.endedAt)
         .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
-
       for (const session of candidates) {
         if (!session.sessionFile) continue;
-        try {
-          const lines = fs.readFileSync(session.sessionFile, "utf-8").split("\n").filter(Boolean);
-          for (let i = lines.length - 1; i >= 0; i--) {
-            try {
-              const event = JSON.parse(lines[i]) as {
-                type: string;
-                message?: { role: string; content: unknown };
-              };
-              if (event.type !== "message" || event.message?.role !== "assistant") continue;
-              const content = event.message.content;
-              let text = "";
-              if (Array.isArray(content)) {
-                text = (content as Array<{ type: string; text?: string }>)
-                  .filter((c) => c.type === "text" || c.type === "output_text")
-                  .map((c) => c.text ?? "")
-                  .join("");
-              } else if (typeof content === "string") {
-                text = content;
-              }
-              if (text.trim()) return text.trim();
-            } catch { /* skip malformed line */ }
-          }
-        } catch { /* session file not readable */ }
+        const text = readSubagentSessionText(session.sessionFile);
+        if (text) return text;
       }
     } catch { /* sessions.json not readable */ }
+  }
+
+  return null;
+}
+
+function readSubagentSessionText(sessionFile: string): string | null {
+  try {
+    const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const event = JSON.parse(lines[i]) as { type: string; message?: { role: string; content: unknown } };
+        if (event.type !== "message" || event.message?.role !== "assistant") continue;
+        const content = event.message.content;
+        let text = "";
+        if (Array.isArray(content)) {
+          text = (content as Array<{ type: string; text?: string }>)
+            .filter((c) => c.type === "text" || c.type === "output_text")
+            .map((c) => c.text ?? "")
+            .join("");
+        } else if (typeof content === "string") {
+          text = content;
+        }
+        if (text.trim()) return text.trim();
+      } catch { /* skip malformed line */ }
+    }
+  } catch { /* session file not readable */ }
+  return null;
+}
+
+/**
+ * Scan all sub-agent directories for a session that started after
+ * requestStartTime and has since completed.
+ *
+ * Strategy: check for 10s for any new session to appear (bail if none),
+ * then wait up to 80s more for it to complete. Avoids a flat 90s wait
+ * on every request that had no delegation.
+ */
+async function findAnySubagentResult(
+  orchAgentId: string,
+  requestStartTime: number,
+): Promise<{ agentId: string; text: string } | null> {
+  const ids = listSubagentIds(orchAgentId);
+  if (ids.length === 0) return null;
+
+  const findSessionDeadline = Date.now() + 10_000;
+  const completionDeadline = Date.now() + 90_000;
+  let foundSession: { id: string; sessionFile: string } | null = null;
+
+  // Phase 1: wait up to 10s for any new sub-agent session to appear
+  while (!foundSession && Date.now() < findSessionDeadline) {
+    await delay(2000);
+    for (const id of ids) {
+      const sessionsJsonPath = path.join(getOpenClawHome(), "agents", id, "sessions", "sessions.json");
+      try {
+        const raw = fs.readFileSync(sessionsJsonPath, "utf-8");
+        const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
+        const candidates = Object.values(sessions)
+          .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile)
+          .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
+        if (candidates[0]?.sessionFile) {
+          foundSession = { id, sessionFile: candidates[0].sessionFile };
+          break;
+        }
+      } catch { /* not readable */ }
+    }
+  }
+
+  if (!foundSession) return null; // no delegation detected — return quickly
+
+  // Phase 2: wait up to total 90s for the found session to complete
+  while (Date.now() < completionDeadline) {
+    // Check if endedAt is set in sessions.json
+    const sessionsJsonPath = path.join(getOpenClawHome(), "agents", foundSession.id, "sessions", "sessions.json");
+    try {
+      const raw = fs.readFileSync(sessionsJsonPath, "utf-8");
+      const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
+      const candidates = Object.values(sessions)
+        .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile && s.endedAt)
+        .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
+      if (candidates[0]?.sessionFile) {
+        const text = readSubagentSessionText(candidates[0].sessionFile);
+        if (text) return { agentId: foundSession.id, text };
+      }
+    } catch { /* not readable */ }
+    await delay(2000);
   }
 
   return null;
@@ -364,7 +440,7 @@ async function autoRelaySubagentResult(
   ctrl: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
   opts: {
-    spawnedAgentId: string;
+    spawnedAgentId: string | null; // null = scan all sub-agents
     requestStartTime: number;
     orchAgentId: string;
     sessionKey: string | undefined;
@@ -375,11 +451,20 @@ async function autoRelaySubagentResult(
 ): Promise<void> {
   const { spawnedAgentId, requestStartTime, orchAgentId, sessionKey, gwUrl, token, gwHeaders } = opts;
 
-  const result = await pollForSubagentResult(spawnedAgentId, requestStartTime);
+  let result: string | null = null;
+  let resolvedAgentId = spawnedAgentId ?? "sub-agent";
+
+  if (spawnedAgentId) {
+    result = await pollForSubagentResult(spawnedAgentId, requestStartTime);
+  } else {
+    const found = await findAnySubagentResult(orchAgentId, requestStartTime);
+    if (found) { result = found.text; resolvedAgentId = found.agentId; }
+  }
+
   if (!result) return;
 
   // Fire a second orchestrator turn with the sub-agent result
-  const continuationInput = `[Subagent ${spawnedAgentId} completed its task. Result: "${result}" — please relay this to the user now.]`;
+  const continuationInput = `[Subagent ${resolvedAgentId} completed its task. Result: "${result}" — please relay this to the user now.]`;
 
   const headers: Record<string, string> = { ...gwHeaders, "Content-Type": "application/json" };
   if (sessionKey) headers["x-openclaw-session-key"] = sessionKey;
@@ -491,18 +576,19 @@ async function tryStreamingResponse(
         })) {
           ctrl.enqueue(encoder.encode(delta));
         }
-        // Auto-relay the first sub-agent response back through Em
-        if (spawnedAgentIds.length > 0) {
-          await autoRelaySubagentResult(ctrl, encoder, {
-            spawnedAgentId: spawnedAgentIds[0],
-            requestStartTime,
-            orchAgentId: agentId,
-            sessionKey,
-            gwUrl,
-            token,
-            gwHeaders: baseHeaders,
-          });
-        }
+        // Auto-relay the first sub-agent response back through Em.
+        // If sessions_spawn was detected in the stream, target that specific agent.
+        // Otherwise scan all sub-agent directories (handles cases where the model
+        // used text-based delegation without a tool call).
+        await autoRelaySubagentResult(ctrl, encoder, {
+          spawnedAgentId: spawnedAgentIds.length > 0 ? spawnedAgentIds[0] : null,
+          requestStartTime,
+          orchAgentId: agentId,
+          sessionKey,
+          gwUrl,
+          token,
+          gwHeaders: baseHeaders,
+        });
       } catch {
         // Stream interrupted — ok
       } finally {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -168,6 +168,10 @@ async function* parseOpenResponsesStream(
   let buffer = "";
   // Track in-flight tool calls so we can emit start/end markers
   const activeCalls = new Map<string, string>(); // callId → toolName
+  // Track stream state for commentary-fallback detection
+  let accumulatedDeltaText = "";
+  let finalDoneText: string | null = null;
+  let completedStatus: string | null = null;
 
   while (true) {
     const { done, value } = await reader.read();
@@ -184,14 +188,39 @@ async function* parseOpenResponsesStream(
     for (const line of lines) {
       if (!line.startsWith("data: ")) continue;
       const data = line.slice(6);
-      if (data === "[DONE]") return;
+      if (data === "[DONE]") {
+        // Before returning: if the response failed but we streamed real text,
+        // the commentary content is already in the client's buffer. Add a
+        // subtle note so the user knows the primary model was unavailable.
+        if (
+          completedStatus === "failed" &&
+          accumulatedDeltaText.trim() &&
+          (finalDoneText === "No response from OpenClaw." || !finalDoneText)
+        ) {
+          yield "\n\n*[⚡ via fallback model — primary unavailable]*";
+        }
+        return;
+      }
 
       try {
         const event = JSON.parse(data);
 
-        // ── Text deltas (existing) ──
+        // ── Text deltas ──
         if (event.type === "response.output_text.delta" && event.delta) {
+          accumulatedDeltaText += event.delta;
           yield event.delta;
+          continue;
+        }
+
+        // ── Track final done text (to detect "No response from OpenClaw." override) ──
+        if (event.type === "response.output_text.done") {
+          finalDoneText = typeof event.text === "string" ? event.text : null;
+          continue;
+        }
+
+        // ── Track overall completion status ──
+        if (event.type === "response.completed") {
+          completedStatus = event.response?.status ?? null;
           continue;
         }
 
@@ -293,20 +322,6 @@ type SubagentSessionRecord = {
   sessionFile?: string;
 };
 
-/**
- * Return the list of sub-agent IDs to scan (all agent dirs except the orchestrator).
- */
-function listSubagentIds(orchAgentId: string): string[] {
-  try {
-    const agentsDir = path.join(getOpenClawHome(), "agents");
-    return fs
-      .readdirSync(agentsDir, { withFileTypes: true })
-      .filter((e) => e.isDirectory() && e.name !== orchAgentId)
-      .map((e) => e.name);
-  } catch {
-    return [];
-  }
-}
 
 /**
  * Poll ~/.openclaw/agents/{agentId}/sessions/sessions.json until a session
@@ -370,77 +385,20 @@ function readSubagentSessionText(sessionFile: string): string | null {
   return null;
 }
 
-/**
- * Scan all sub-agent directories for a session that started after
- * requestStartTime and has since completed.
- *
- * Strategy: check for 10s for any new session to appear (bail if none),
- * then wait up to 80s more for it to complete. Avoids a flat 90s wait
- * on every request that had no delegation.
- */
-async function findAnySubagentResult(
-  orchAgentId: string,
-  requestStartTime: number,
-): Promise<{ agentId: string; text: string } | null> {
-  const ids = listSubagentIds(orchAgentId);
-  if (ids.length === 0) return null;
-
-  const findSessionDeadline = Date.now() + 10_000;
-  const completionDeadline = Date.now() + 90_000;
-  let foundSession: { id: string; sessionFile: string } | null = null;
-
-  // Phase 1: wait up to 10s for any new sub-agent session to appear
-  while (!foundSession && Date.now() < findSessionDeadline) {
-    await delay(2000);
-    for (const id of ids) {
-      const sessionsJsonPath = path.join(getOpenClawHome(), "agents", id, "sessions", "sessions.json");
-      try {
-        const raw = fs.readFileSync(sessionsJsonPath, "utf-8");
-        const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
-        const candidates = Object.values(sessions)
-          .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile)
-          .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
-        if (candidates[0]?.sessionFile) {
-          foundSession = { id, sessionFile: candidates[0].sessionFile };
-          break;
-        }
-      } catch { /* not readable */ }
-    }
-  }
-
-  if (!foundSession) return null; // no delegation detected — return quickly
-
-  // Phase 2: wait up to total 90s for the found session to complete
-  while (Date.now() < completionDeadline) {
-    // Check if endedAt is set in sessions.json
-    const sessionsJsonPath = path.join(getOpenClawHome(), "agents", foundSession.id, "sessions", "sessions.json");
-    try {
-      const raw = fs.readFileSync(sessionsJsonPath, "utf-8");
-      const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
-      const candidates = Object.values(sessions)
-        .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile && s.endedAt)
-        .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
-      if (candidates[0]?.sessionFile) {
-        const text = readSubagentSessionText(candidates[0].sessionFile);
-        if (text) return { agentId: foundSession.id, text };
-      }
-    } catch { /* not readable */ }
-    await delay(2000);
-  }
-
-  return null;
-}
 
 /**
- * After Em's first stream completes and sessions_spawn was detected,
- * poll for the sub-agent result then fire a second Em turn and pipe
+ * After Em's first stream completes and sessions_spawn was detected in the
+ * stream, poll for the sub-agent result then fire a second Em turn and pipe
  * its response into the already-open stream controller.
+ *
+ * If spawnedAgentId is null (no sessions_spawn detected), returns immediately
+ * — avoids a 10 s scan on every non-delegation request.
  */
 async function autoRelaySubagentResult(
   ctrl: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
   opts: {
-    spawnedAgentId: string | null; // null = scan all sub-agents
+    spawnedAgentId: string | null;
     requestStartTime: number;
     orchAgentId: string;
     sessionKey: string | undefined;
@@ -449,22 +407,16 @@ async function autoRelaySubagentResult(
     gwHeaders: Record<string, string>;
   },
 ): Promise<void> {
-  const { spawnedAgentId, requestStartTime, orchAgentId, sessionKey, gwUrl, token, gwHeaders } = opts;
+  const { spawnedAgentId, requestStartTime, sessionKey, gwUrl, token, gwHeaders } = opts;
 
-  let result: string | null = null;
-  let resolvedAgentId = spawnedAgentId ?? "sub-agent";
+  // Only relay when sessions_spawn was explicitly detected in the stream.
+  if (!spawnedAgentId) return;
 
-  if (spawnedAgentId) {
-    result = await pollForSubagentResult(spawnedAgentId, requestStartTime);
-  } else {
-    const found = await findAnySubagentResult(orchAgentId, requestStartTime);
-    if (found) { result = found.text; resolvedAgentId = found.agentId; }
-  }
-
+  const result = await pollForSubagentResult(spawnedAgentId, requestStartTime);
   if (!result) return;
 
   // Fire a second orchestrator turn with the sub-agent result
-  const continuationInput = `[Subagent ${resolvedAgentId} completed its task. Result: "${result}" — please relay this to the user now.]`;
+  const continuationInput = `[Subagent ${spawnedAgentId} completed its task. Result: "${result}" — please relay this to the user now.]`;
 
   const headers: Record<string, string> = { ...gwHeaders, "Content-Type": "application/json" };
   if (sessionKey) headers["x-openclaw-session-key"] = sessionKey;
@@ -477,7 +429,7 @@ async function autoRelaySubagentResult(
       method: "POST",
       headers,
       body: JSON.stringify({
-        model: `openclaw:${orchAgentId}`,
+        model: `openclaw:${opts.orchAgentId}`,
         input: continuationInput,
         stream: true,
       }),
@@ -576,10 +528,7 @@ async function tryStreamingResponse(
         })) {
           ctrl.enqueue(encoder.encode(delta));
         }
-        // Auto-relay the first sub-agent response back through Em.
-        // If sessions_spawn was detected in the stream, target that specific agent.
-        // Otherwise scan all sub-agent directories (handles cases where the model
-        // used text-based delegation without a tool call).
+        // Auto-relay the sub-agent result when sessions_spawn was detected.
         await autoRelaySubagentResult(ctrl, encoder, {
           spawnedAgentId: spawnedAgentIds.length > 0 ? spawnedAgentIds[0] : null,
           requestStartTime,

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,8 @@
 import { runOpenResponsesText, guessMime } from "@/lib/openresponses";
-import { getGatewayUrl, getGatewayToken } from "@/lib/paths";
+import { getGatewayUrl, getGatewayToken, getOpenClawHome } from "@/lib/paths";
 import { waitForResponsesEndpoint, triggerResponsesEndpointSetup } from "@/app/api/gateway/route";
+import fs from "fs";
+import path from "path";
 
 /**
  * Chat endpoint that sends a message to an OpenClaw agent and returns the response.
@@ -160,6 +162,7 @@ function toolDisplayName(name: string): string {
  */
 async function* parseOpenResponsesStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
+  opts?: { onSpawn?: (agentId: string) => void },
 ): AsyncGenerator<string> {
   const decoder = new TextDecoder();
   let buffer = "";
@@ -231,6 +234,7 @@ async function* parseOpenResponsesStream(
         if (event.type === "response.function_call_arguments.done") {
           const callId = event.call_id || "";
           if (callId && activeCalls.has(callId)) {
+            const callName = activeCalls.get(callId);
             try {
               const args = typeof event.arguments === "string"
                 ? event.arguments
@@ -238,6 +242,13 @@ async function* parseOpenResponsesStream(
               // Emit args as a detail line inside the tool block
               if (args && args !== "{}") {
                 yield `\n\u{200B}[[TOOL_ARGS:${callId}:${args}]]\u{200B}\n`;
+              }
+              // Capture sessions_spawn agentId for auto-relay
+              if (callName === "sessions_spawn" && opts?.onSpawn) {
+                try {
+                  const parsed = JSON.parse(args) as { agentId?: string };
+                  if (parsed.agentId) opts.onSpawn(parsed.agentId);
+                } catch { /* ignore malformed args */ }
               }
             } catch { /* skip malformed args */ }
           }
@@ -271,6 +282,131 @@ async function* parseOpenResponsesStream(
         }
       }
     }
+  }
+}
+
+// ── Sub-agent auto-relay helpers ─────────────────────
+
+type SubagentSessionRecord = {
+  startedAt?: number;
+  endedAt?: number;
+  sessionFile?: string;
+};
+
+/**
+ * Poll ~/.openclaw/agents/{agentId}/sessions/sessions.json until a session
+ * started after `requestStartTime` finishes, then return its final assistant
+ * message text.  Returns null on timeout.
+ */
+async function pollForSubagentResult(
+  spawnedAgentId: string,
+  requestStartTime: number,
+  timeoutMs = 90_000,
+): Promise<string | null> {
+  const sessionsJsonPath = path.join(
+    getOpenClawHome(),
+    "agents",
+    spawnedAgentId,
+    "sessions",
+    "sessions.json",
+  );
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    await delay(2000);
+    try {
+      const raw = fs.readFileSync(sessionsJsonPath, "utf-8");
+      const sessions = JSON.parse(raw) as Record<string, SubagentSessionRecord>;
+
+      // Find completed sub-agent sessions started after our request began
+      const candidates = Object.values(sessions)
+        .filter((s) => s.startedAt && s.startedAt > requestStartTime - 5_000 && s.sessionFile && s.endedAt)
+        .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0));
+
+      for (const session of candidates) {
+        if (!session.sessionFile) continue;
+        try {
+          const lines = fs.readFileSync(session.sessionFile, "utf-8").split("\n").filter(Boolean);
+          for (let i = lines.length - 1; i >= 0; i--) {
+            try {
+              const event = JSON.parse(lines[i]) as {
+                type: string;
+                message?: { role: string; content: unknown };
+              };
+              if (event.type !== "message" || event.message?.role !== "assistant") continue;
+              const content = event.message.content;
+              let text = "";
+              if (Array.isArray(content)) {
+                text = (content as Array<{ type: string; text?: string }>)
+                  .filter((c) => c.type === "text" || c.type === "output_text")
+                  .map((c) => c.text ?? "")
+                  .join("");
+              } else if (typeof content === "string") {
+                text = content;
+              }
+              if (text.trim()) return text.trim();
+            } catch { /* skip malformed line */ }
+          }
+        } catch { /* session file not readable */ }
+      }
+    } catch { /* sessions.json not readable */ }
+  }
+
+  return null;
+}
+
+/**
+ * After Em's first stream completes and sessions_spawn was detected,
+ * poll for the sub-agent result then fire a second Em turn and pipe
+ * its response into the already-open stream controller.
+ */
+async function autoRelaySubagentResult(
+  ctrl: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  opts: {
+    spawnedAgentId: string;
+    requestStartTime: number;
+    orchAgentId: string;
+    sessionKey: string | undefined;
+    gwUrl: string;
+    token: string;
+    gwHeaders: Record<string, string>;
+  },
+): Promise<void> {
+  const { spawnedAgentId, requestStartTime, orchAgentId, sessionKey, gwUrl, token, gwHeaders } = opts;
+
+  const result = await pollForSubagentResult(spawnedAgentId, requestStartTime);
+  if (!result) return;
+
+  // Fire a second orchestrator turn with the sub-agent result
+  const continuationInput = `[Subagent ${spawnedAgentId} completed its task. Result: "${result}" — please relay this to the user now.]`;
+
+  const headers: Record<string, string> = { ...gwHeaders, "Content-Type": "application/json" };
+  if (sessionKey) headers["x-openclaw-session-key"] = sessionKey;
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const secondController = new AbortController();
+  const secondTimeout = setTimeout(() => secondController.abort(), 120_000);
+  try {
+    const secondRes = await fetch(`${gwUrl}/v1/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: `openclaw:${orchAgentId}`,
+        input: continuationInput,
+        stream: true,
+      }),
+      signal: secondController.signal,
+    });
+    if (secondRes.ok && secondRes.body) {
+      const secondReader = secondRes.body.getReader();
+      for await (const delta of parseOpenResponsesStream(secondReader)) {
+        ctrl.enqueue(encoder.encode(delta));
+      }
+    }
+  } catch { /* continuation failed — stream what we have */ }
+  finally {
+    clearTimeout(secondTimeout);
   }
 }
 
@@ -342,12 +478,30 @@ async function tryStreamingResponse(
   // Stream text deltas as plain text for TextStreamChatTransport
   const reader = gwRes.body.getReader();
   const encoder = new TextEncoder();
+  const requestStartTime = Date.now();
+  const spawnedAgentIds: string[] = [];
+  // Headers for sub-agent relay (without session-key — added per-request in autoRelaySubagentResult)
+  const baseHeaders: Record<string, string> = { "x-openclaw-agent-id": agentId };
 
   const stream = new ReadableStream({
     async start(ctrl) {
       try {
-        for await (const delta of parseOpenResponsesStream(reader)) {
+        for await (const delta of parseOpenResponsesStream(reader, {
+          onSpawn: (spawned) => spawnedAgentIds.push(spawned),
+        })) {
           ctrl.enqueue(encoder.encode(delta));
+        }
+        // Auto-relay the first sub-agent response back through Em
+        if (spawnedAgentIds.length > 0) {
+          await autoRelaySubagentResult(ctrl, encoder, {
+            spawnedAgentId: spawnedAgentIds[0],
+            requestStartTime,
+            orchAgentId: agentId,
+            sessionKey,
+            gwUrl,
+            token,
+            gwHeaders: baseHeaders,
+          });
         }
       } catch {
         // Stream interrupted — ok

--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -328,9 +328,14 @@ function AgentNodeComponent({ data }: NodeProps) {
             </span>
             <span className={cn("h-2 w-2 rounded-full", sc.dot)} />
           </div>
-          <p className="truncate text-xs text-muted-foreground">
-            {shortModel(agent.model)}
-          </p>
+          <div>
+            <p className="truncate text-xs font-medium text-muted-foreground">
+              {shortModel(agent.model)}
+            </p>
+            <p className="truncate text-[10px] text-muted-foreground/50">
+              {agent.model.split("/")[0]}
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/components/agents-view.tsx
+++ b/src/components/agents-view.tsx
@@ -272,9 +272,10 @@ function AgentNodeComponent({ data }: NodeProps) {
     agent: Agent;
     idx: number;
     selected: boolean;
+    role: "orchestrator" | "sub-agent" | "standalone";
     onClick: () => void;
   };
-  const { agent, idx, selected } = d;
+  const { agent, idx, selected, role } = d;
   const sc = STATUS_COLORS[agent.status] || STATUS_COLORS.unknown;
 
   return (
@@ -291,6 +292,27 @@ function AgentNodeComponent({ data }: NodeProps) {
       <Handle type="source" position={Position.Right} className="!bg-blue-500 !border-blue-400 !w-2 !h-2" />
       <Handle type="source" position={Position.Right} id="sub" className="!bg-[var(--accent-brand)] !border-[var(--accent-brand)] !w-2 !h-2" />
       <Handle type="target" position={Position.Left} id="parent" className="!bg-[var(--accent-brand)] !border-[var(--accent-brand)] !w-2 !h-2" />
+
+      {/* Role badge */}
+      {role !== "standalone" && (
+        <div className="mb-1.5">
+          {role === "orchestrator" ? (
+            <span
+              className="rounded bg-violet-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-violet-300 uppercase tracking-wide"
+              title="This agent orchestrates other agents via agent_to_agent tool calls"
+            >
+              ⬡ Orchestrator
+            </span>
+          ) : (
+            <span
+              className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 uppercase tracking-wide"
+              title="Invoked by the orchestrator agent via tool call — not the primary chat target"
+            >
+              ↳ Sub-agent
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Header */}
       <div className="flex items-center gap-2">
@@ -597,10 +619,7 @@ function buildGraph(
     if (dagreGraph) dagreGraph.setEdge(gatewayId, `agent-${agent.id}`);
   }
 
-  // Gateway → sub-agents (so they're at the same rank as their peers)
-  for (const sub of subAgents) {
-    if (dagreGraph) dagreGraph.setEdge(gatewayId, `agent-${sub.id}`);
-  }
+  // Sub-agents rank after their parent, not after gateway — skip gateway edge for them
 
   // Parent → sub-agent (register all delegation pairs for dagre)
   for (const parent of agents) {
@@ -676,6 +695,12 @@ function buildGraph(
     const nodeId = `agent-${agent.id}`;
     const idx = agents.indexOf(agent);
     const isSub = subagentIds.has(agent.id);
+    const isOrchestrator = agent.subagents.length > 0;
+    const role: "orchestrator" | "sub-agent" | "standalone" = isOrchestrator
+      ? "orchestrator"
+      : isSub
+        ? "sub-agent"
+        : "standalone";
     const fallbackIdx = isSub ? subAgents.indexOf(agent) : topLevelAgents.indexOf(agent);
     const fallbackY = FALLBACK_GATEWAY_Y + fallbackIdx * FALLBACK_AGENT_SPACING_Y;
 
@@ -686,21 +711,24 @@ function buildGraph(
       data: {
         agent,
         idx,
+        role,
         selected: selectedId === agent.id,
         onClick: () => onSelectAgent(agent.id),
       },
       draggable: true,
     });
 
-    // Gateway → Agent
-    edges.push({
-      id: `gw-${agent.id}`,
-      source: gatewayId,
-      target: nodeId,
-      type: "default",
-      style: gatewayEdgeStyle,
-      markerEnd: gatewayEdgeMarker,
-    });
+    // Gateway → Agent edge (skip for configured sub-agents — they connect via delegation edges)
+    if (!isSub) {
+      edges.push({
+        id: `gw-${agent.id}`,
+        source: gatewayId,
+        target: nodeId,
+        type: "default",
+        style: gatewayEdgeStyle,
+        markerEnd: gatewayEdgeMarker,
+      });
+    }
   }
 
   // ── 3. Sub-agent delegation edges ──
@@ -719,7 +747,7 @@ function buildGraph(
         type: "default",
         animated: true,
         style: { stroke: AGENT_GRAPH_COLORS.delegation, strokeWidth: 1.5, strokeDasharray: "5 4" },
-        label: "delegates",
+        label: "invokes",
         labelStyle: { fill: AGENT_GRAPH_COLORS.delegationLabel, fontSize: 10 },
         labelBgStyle: { fill: "var(--card)", fillOpacity: 0.9 },
         markerEnd: {

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -107,25 +107,55 @@ function loadStoredSessionKey(agentId: string): string {
   return k;
 }
 
+// Current stored-message format version. Bump when the shape changes incompatibly.
+const CHAT_MSGS_VERSION = 2;
+
+/**
+ * Strip file parts from a stored message's parts array.
+ * File attachments (images, docs) are data-URL blobs that become large in
+ * localStorage and can produce malformed payloads when replayed as history.
+ * We keep text parts so conversation context survives; the binary data doesn't.
+ */
+function sanitizeParts(parts: unknown[]): unknown[] {
+  return parts.filter(
+    (p) => p && typeof p === "object" && (p as Record<string, unknown>).type !== "file"
+  );
+}
+
 function loadStoredMessages(agentId: string): unknown[] {
   if (typeof window === "undefined") return [];
   try {
     const raw = localStorage.getItem(CHAT_MSGS_LS(agentId));
     if (!raw) return [];
-    const parsed = JSON.parse(raw) as Array<Record<string, unknown>>;
-    if (!Array.isArray(parsed)) return [];
+    const stored = JSON.parse(raw) as { v?: number; msgs?: unknown[] } | unknown[];
+    // Support both versioned { v, msgs } and legacy plain-array shapes
+    const arr: unknown[] = Array.isArray(stored)
+      ? stored
+      : Array.isArray((stored as { msgs?: unknown[] }).msgs)
+        ? (stored as { msgs: unknown[] }).msgs
+        : [];
+    if (!Array.isArray(arr) || arr.length === 0) return [];
     const cutoff = Date.now() - CHAT_MSG_TTL_MS;
-    return parsed
+    const sanitized = arr
       .filter((m) => {
-        if (!m.createdAt) return true;
-        const t = typeof m.createdAt === "string" ? Date.parse(m.createdAt as string) : Number(m.createdAt);
+        if (!m || typeof m !== "object") return false;
+        const msg = m as Record<string, unknown>;
+        if (!msg.createdAt) return true;
+        const t = typeof msg.createdAt === "string" ? Date.parse(msg.createdAt) : Number(msg.createdAt);
         return isNaN(t) || t > cutoff;
       })
       .slice(-CHAT_MSGS_MAX)
-      .map((m) => ({
-        ...m,
-        createdAt: m.createdAt ? new Date(m.createdAt as string | number) : undefined,
-      }));
+      .map((m) => {
+        const msg = { ...(m as Record<string, unknown>) };
+        // Strip file/image parts — data URLs are large and can cause gateway rejections
+        // when replayed as multi-turn history. Text parts are preserved.
+        if (Array.isArray(msg.parts)) {
+          msg.parts = sanitizeParts(msg.parts as unknown[]);
+        }
+        msg.createdAt = msg.createdAt ? new Date(msg.createdAt as string | number) : undefined;
+        return msg;
+      });
+    return sanitized;
   } catch { return []; }
 }
 
@@ -482,6 +512,7 @@ function ChatPanel({
   modelsLoaded,
   isPostOnboarding,
   onClearPostOnboarding,
+  onRegisterClear,
 }: {
   agentId: string;
   agentName: string;
@@ -494,6 +525,7 @@ function ChatPanel({
   modelsLoaded: boolean;
   isPostOnboarding: boolean;
   onClearPostOnboarding: () => void;
+  onRegisterClear: (fn: () => void) => void;
 }) {
   const postOnboardingStarterPrompt = "Say hello and tell me how you can help me today.";
   const timeFormat = useSyncExternalStore(
@@ -568,10 +600,19 @@ function ChatPanel({
   });
 
   // Persist messages to localStorage so nav away and back restores history.
+  // File parts are stripped before storage — data URLs are large and cause
+  // gateway rejections when replayed as history context.
   useEffect(() => {
     if (messages.length === 0) return;
     try {
-      localStorage.setItem(CHAT_MSGS_LS(agentId), JSON.stringify(messages.slice(-CHAT_MSGS_MAX)));
+      const toStore = messages.slice(-CHAT_MSGS_MAX).map((m) => {
+        const msg = { ...m } as Record<string, unknown>;
+        if (Array.isArray(msg.parts)) {
+          msg.parts = sanitizeParts(msg.parts as unknown[]);
+        }
+        return msg;
+      });
+      localStorage.setItem(CHAT_MSGS_LS(agentId), JSON.stringify({ v: CHAT_MSGS_VERSION, msgs: toStore }));
     } catch { /* localStorage full or unavailable */ }
   }, [messages, agentId]);
 
@@ -688,6 +729,11 @@ function ChatPanel({
     } catch { /* ignore */ }
     setTimeout(() => inputRef.current?.focus(), 100);
   }, [agentId, setMessages]);
+
+  // Register clearChat with the parent so the header can invoke it.
+  useEffect(() => {
+    onRegisterClear(clearChat);
+  }, [clearChat, onRegisterClear]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -1187,6 +1233,8 @@ export function ChatView({ isVisible = true }: { isVisible?: boolean }) {
   const [mountedAgents, setMountedAgents] = useState<Set<string>>(
     new Set(["main"])
   );
+  // Holds clearChat callbacks registered by each mounted ChatPanel
+  const clearChatFnsRef = useRef(new Map<string, () => void>());
 
   // Fetch chat bootstrap data on mount (gateway config + sessions only)
   const bootstrapLoadedRef = useRef(false);
@@ -1309,7 +1357,7 @@ export function ChatView({ isVisible = true }: { isVisible?: boolean }) {
       <div className="shrink-0 border-b border-stone-200 bg-stone-50 px-4 py-3 md:px-6 dark:border-stone-700 dark:bg-stone-900">
         <div className="flex items-center gap-2.5">
           <span className="text-sm">{currentAgent?.emoji || "🤖"}</span>
-          <div className="flex flex-col min-w-0">
+          <div className="flex flex-col min-w-0 flex-1">
             <span className="text-sm font-medium text-stone-700 dark:text-stone-200">
               {currentAgentTitle}
               {currentAgent && currentAgent.id !== currentAgentTitle && (
@@ -1324,6 +1372,15 @@ export function ChatView({ isVisible = true }: { isVisible?: boolean }) {
               </span>
             )}
           </div>
+          {/* Clear conversation — always reachable from header as an escape hatch */}
+          <button
+            type="button"
+            title="Clear conversation"
+            onClick={() => clearChatFnsRef.current.get(selectedAgent)?.()}
+            className="ml-auto flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/40 transition-colors hover:bg-muted hover:text-foreground/70"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
         </div>
       </div>
 
@@ -1424,6 +1481,7 @@ export function ChatView({ isVisible = true }: { isVisible?: boolean }) {
               modelsLoaded={modelsLoaded}
               isPostOnboarding={isPostOnboarding}
               onClearPostOnboarding={clearPostOnboarding}
+              onRegisterClear={(fn) => clearChatFnsRef.current.set(agentId, fn)}
             />
           );
         })

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1309,14 +1309,21 @@ export function ChatView({ isVisible = true }: { isVisible?: boolean }) {
       <div className="shrink-0 border-b border-stone-200 bg-stone-50 px-4 py-3 md:px-6 dark:border-stone-700 dark:bg-stone-900">
         <div className="flex items-center gap-2.5">
           <span className="text-sm">{currentAgent?.emoji || "🤖"}</span>
-          <span className="text-sm font-medium text-stone-700 dark:text-stone-200">
-            {currentAgentTitle}
-          </span>
-          {showSecondaryModelLabel && (
-            <span className="text-xs text-muted-foreground">
-              {currentAgentModelLabel}
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm font-medium text-stone-700 dark:text-stone-200">
+              {currentAgentTitle}
+              {currentAgent && currentAgent.id !== currentAgentTitle && (
+                <span className="ml-1.5 text-xs font-normal text-muted-foreground/60">
+                  ({currentAgent.id})
+                </span>
+              )}
             </span>
-          )}
+            {currentAgentModelLabel && (
+              <span className="text-[10px] text-muted-foreground/70 leading-tight">
+                {currentAgentModelLabel}
+              </span>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -594,7 +594,7 @@ function ChatPanel({
     []
   );
 
-  const { messages, sendMessage, status, setMessages, error } = useChat({
+  const { messages, sendMessage, status, setMessages, error, stop, clearError } = useChat({
     transport,
     messages: initialMessages,
   });
@@ -617,6 +617,75 @@ function ChatPanel({
   }, [messages, agentId]);
 
   const isLoading = status === "submitted" || status === "streaming";
+
+  // Mirror isLoading in a ref so visibility-change callbacks see current value
+  // without needing to re-register the event listener on every render.
+  const isLoadingRef = useRef(isLoading);
+  useEffect(() => { isLoadingRef.current = isLoading; }, [isLoading]);
+
+  // Show a manual "Recover" button if still loading after 3 minutes.
+  // GPT-5.4 reasoning can take 60-120s; 3 min means the stream is almost
+  // certainly stuck/dropped.
+  const [showRecoverButton, setShowRecoverButton] = useState(false);
+  useEffect(() => {
+    if (!isLoading) { setShowRecoverButton(false); return; }
+    const t = setTimeout(() => { if (isLoadingRef.current) setShowRecoverButton(true); }, 3 * 60 * 1000);
+    return () => clearTimeout(t);
+  }, [isLoading]);
+
+  // Fetch the last completed assistant message from the gateway session file.
+  // The gateway persists every response to disk even if the SSE stream was
+  // dropped by the browser — so this lets us recover after a tab switch.
+  const recoverLastResponse = useCallback(async () => {
+    const sessionKey = chatSessionKeyRef.current;
+    if (!sessionKey || !isLoadingRef.current) return;
+    try {
+      const res = await fetch(
+        `/api/chat/last-response?agentId=${encodeURIComponent(agentId)}&sessionKey=${encodeURIComponent(sessionKey)}`,
+      );
+      if (!res.ok) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = await res.json() as { text: string };
+      if (!data.text) return;
+
+      // Abort the in-flight stream, then inject the recovered message.
+      stop();
+      await new Promise<void>((r) => setTimeout(r, 200));
+      clearError();
+
+      const recovered = {
+        id: crypto.randomUUID(),
+        role: "assistant" as const,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        parts: [{ type: "text" as const, text: data.text }] as any[],
+        createdAt: new Date(),
+      };
+
+      // Drop a trailing empty/partial assistant message if present, then append.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cur = messages as any[];
+      const last = cur[cur.length - 1];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const hasText = (m: any) => Array.isArray(m?.parts) && m.parts.some((p: any) => p.type === "text" && p.text?.trim());
+      const base = last?.role === "assistant" && !hasText(last) ? cur.slice(0, -1) : cur;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setMessages([...base, recovered] as any);
+      setShowRecoverButton(false);
+    } catch { /* recovery failed silently */ }
+  }, [agentId, messages, stop, clearError, setMessages]);
+
+  // Auto-recover when the tab becomes visible and a request was in-flight.
+  // Chrome throttles/drops SSE connections in backgrounded tabs; the gateway
+  // already has the completed response on disk by the time the user returns.
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === "visible" && isLoadingRef.current) {
+        void recoverLastResponse();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [recoverLastResponse]);
   const noApiKeys = modelsLoaded && availableModels.length === 0;
 
   // ── Detect new assistant messages → trigger unread notification ──
@@ -944,6 +1013,21 @@ function ChatPanel({
                 </div>
               );
             })}
+
+            {/* Stale-stream recovery banner — shown when loading >3 min with no completion */}
+            {isLoading && showRecoverButton && (
+              <div className="mb-4 flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs">
+                <span className="text-amber-400/80">Still waiting for a response&hellip;</span>
+                <button
+                  type="button"
+                  onClick={() => void recoverLastResponse()}
+                  className="ml-auto flex shrink-0 items-center gap-1.5 rounded px-2 py-1 text-xs text-amber-400 transition-colors hover:bg-amber-500/20"
+                >
+                  <RefreshCw className="h-3 w-3" />
+                  Recover last response
+                </button>
+              </div>
+            )}
 
             {/* Loading indicator — only when waiting for first token, not during streaming */}
             {status === "submitted" && (

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -564,7 +564,7 @@ function ChatPanel({
 
   const { messages, sendMessage, status, setMessages, error } = useChat({
     transport,
-    initialMessages,
+    messages: initialMessages,
   });
 
   // Persist messages to localStorage so nav away and back restores history.

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -90,6 +90,45 @@ function createChatSessionKey(agentId: string) {
   return `agent:${agentId}:mission-control:${suffix}`;
 }
 
+// ── Per-agent localStorage persistence ─────────────
+const CHAT_SESSION_LS = (id: string) => `openclaw-session:${id}`;
+const CHAT_MSGS_LS = (id: string) => `openclaw-msgs:${id}`;
+const CHAT_MSGS_MAX = 100;
+const CHAT_MSG_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function loadStoredSessionKey(agentId: string): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const s = localStorage.getItem(CHAT_SESSION_LS(agentId));
+    if (s && s.startsWith(`agent:${agentId}:mission-control:`)) return s;
+  } catch { /* localStorage unavailable */ }
+  const k = createChatSessionKey(agentId);
+  try { localStorage.setItem(CHAT_SESSION_LS(agentId), k); } catch { /* ignore */ }
+  return k;
+}
+
+function loadStoredMessages(agentId: string): unknown[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(CHAT_MSGS_LS(agentId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Array<Record<string, unknown>>;
+    if (!Array.isArray(parsed)) return [];
+    const cutoff = Date.now() - CHAT_MSG_TTL_MS;
+    return parsed
+      .filter((m) => {
+        if (!m.createdAt) return true;
+        const t = typeof m.createdAt === "string" ? Date.parse(m.createdAt as string) : Number(m.createdAt);
+        return isNaN(t) || t > cutoff;
+      })
+      .slice(-CHAT_MSGS_MAX)
+      .map((m) => ({
+        ...m,
+        createdAt: m.createdAt ? new Date(m.createdAt as string | number) : undefined,
+      }));
+  } catch { return []; }
+}
+
 /** Convert File[] to FileUIPart[] (data URLs) for sendMessage */
 async function filesToUIParts(files: File[]): Promise<Array<{ type: "file"; mediaType: string; filename?: string; url: string }>> {
   return Promise.all(
@@ -465,9 +504,10 @@ function ChatPanel({
   const [inputValue, setInputValue] = useState(() =>
     isPostOnboarding && isSelected ? postOnboardingStarterPrompt : ""
   );
-  const chatSessionKeyRef = useRef(
-    typeof window === "undefined" ? "" : createChatSessionKey(agentId)
-  );
+  const chatSessionKeyRef = useRef(loadStoredSessionKey(agentId));
+  // Load prior messages once on mount so navigation away and back restores history.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [initialMessages] = useState<any[]>(() => loadStoredMessages(agentId));
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -485,6 +525,7 @@ function ChatPanel({
     if (existing) return existing;
     const next = createChatSessionKey(agentId);
     chatSessionKeyRef.current = next;
+    try { localStorage.setItem(CHAT_SESSION_LS(agentId), next); } catch { /* ignore */ }
     return next;
   }, [agentId]);
 
@@ -523,7 +564,16 @@ function ChatPanel({
 
   const { messages, sendMessage, status, setMessages, error } = useChat({
     transport,
+    initialMessages,
   });
+
+  // Persist messages to localStorage so nav away and back restores history.
+  useEffect(() => {
+    if (messages.length === 0) return;
+    try {
+      localStorage.setItem(CHAT_MSGS_LS(agentId), JSON.stringify(messages.slice(-CHAT_MSGS_MAX)));
+    } catch { /* localStorage full or unavailable */ }
+  }, [messages, agentId]);
 
   const isLoading = status === "submitted" || status === "streaming";
   const noApiKeys = modelsLoaded && availableModels.length === 0;
@@ -630,7 +680,12 @@ function ChatPanel({
   const clearChat = useCallback(() => {
     setMessages([]);
     prevMsgCountRef.current = 0;
-    chatSessionKeyRef.current = createChatSessionKey(agentId);
+    const newKey = createChatSessionKey(agentId);
+    chatSessionKeyRef.current = newKey;
+    try {
+      localStorage.setItem(CHAT_SESSION_LS(agentId), newKey);
+      localStorage.removeItem(CHAT_MSGS_LS(agentId));
+    } catch { /* ignore */ }
     setTimeout(() => inputRef.current?.focus(), 100);
   }, [agentId, setMessages]);
 

--- a/src/lib/transports/http-transport.ts
+++ b/src/lib/transports/http-transport.ts
@@ -8,7 +8,7 @@
  * Auth: Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>
  */
 
-import { getGatewayUrl } from "../paths";
+import { getGatewayToken, getGatewayUrl } from "../paths";
 import { GatewayRpcClient } from "../gateway-rpc";
 import { parseJsonFromCliOutput, type RunCliResult } from "../openclaw-cli";
 import type { OpenClawClient, TransportMode } from "../openclaw-client";
@@ -19,7 +19,7 @@ export class HttpTransport implements OpenClawClient {
   private rpcClient: GatewayRpcClient | null = null;
 
   constructor(gatewayUrl?: string, token?: string) {
-    this.token = token || process.env.OPENCLAW_GATEWAY_TOKEN || "";
+    this.token = token || process.env.OPENCLAW_GATEWAY_TOKEN || getGatewayToken();
     this.gatewayUrlCache = gatewayUrl || null;
   }
 
@@ -174,7 +174,7 @@ export class HttpTransport implements OpenClawClient {
     timeout = 15000,
   ): Promise<T> {
     if (!this.rpcClient) {
-      this.rpcClient = new GatewayRpcClient(this.gatewayUrlCache || undefined, this.token);
+      this.rpcClient = new GatewayRpcClient(this.gatewayUrlCache || undefined, this.token || undefined);
     }
     return this.rpcClient.request<T>(method, params || {}, timeout);
   }


### PR DESCRIPTION
Layered Ben-specific notes on top of upstream README:
- Pre-flight checks assuming OpenClaw is already installed at ~/.openclaw
- Exact dev command + port caveat (this fork defaults to 127.0.0.1:3000, not 3333)
- Expected 3-agent org chart (Em/main -> claude-cli, claude-code)
- Local-machine gotchas: macOS extended attributes on ~/.openclaw, gateway
  log location in /tmp/openclaw/, qwen3 auto-compaction expectations
- Remote-access paths (SSH tunnel or Tailscale)
- Security reminder: openclaw.json contains bearer + Telegram tokens, never
  commit it.

Upstream's .gitignore globally excludes *.md, so this file is force-added.
