### PR TITLE
Make Mission Control work with OpenClaw 2026.7 (v0.6.0)

### DIFF
--- a/src/app/api/audio/route.ts
+++ b/src/app/api/audio/route.ts
@@ -3,7 +3,7 @@ import { gatewayCall, runCli } from "@/lib/openclaw";
 import { runOpenResponsesText } from "@/lib/openresponses";
 import { readFile, stat } from "fs/promises";
 import { extname, join } from "path";
-import { getOpenClawHome } from "@/lib/paths";
+import { getDefaultAgentId, getOpenClawHome } from "@/lib/paths";
 import { fetchConfig, patchConfig, gatewayConfigPatch } from "@/lib/gateway-config";
 
 /* ── Gather personal context for TTS test phrase generation ── */
@@ -77,11 +77,18 @@ async function generateTestPhrase(): Promise<string> {
       context,
     ].join("\n");
 
+    // "main" is `agents.list`'s mainKey, not an agent id. The RPC rejects it as
+    // unknown, and the CLI silently resolves `--agent main` to a workspace
+    // *inside* the real one, so it targets the wrong place instead of failing.
+    // Ask which agent is actually the default; "main" stays only as the
+    // last-resort value for when the gateway cannot be reached at all.
+    const agentId = (await getDefaultAgentId()) ?? "main";
+
     let output = "";
     try {
       const result = await runOpenResponsesText({
         input: prompt,
-        agentId: "main",
+        agentId,
         timeoutMs: 15000,
       });
       if (!result.ok) {
@@ -90,8 +97,8 @@ async function generateTestPhrase(): Promise<string> {
       output = result.text;
     } catch {
       output = await runCli(
-        ["agent", "--agent", "main", "--message", prompt],
-        15000
+        ["agent", "--agent", agentId, "--message", prompt],
+        30000
       );
     }
     const phrase = output.trim().replace(/^["']|["']$/g, ""); // strip wrapping quotes

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { runOpenResponsesText, guessMime } from "@/lib/openresponses";
 import { getGatewayUrl, getGatewayToken } from "@/lib/paths";
-import { waitForResponsesEndpoint, triggerResponsesEndpointSetup } from "@/app/api/gateway/route";
+import { triggerResponsesEndpointSetup, waitForResponsesEndpoint } from "@/lib/responses-endpoint";
 
 /**
  * Chat endpoint that sends a message to an OpenClaw agent and returns the response.

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -1,7 +1,7 @@
 import { getGatewayUrl, getGatewayToken } from "@/lib/paths";
 import { guessMime } from "@/lib/openresponses";
 import { logRequest, logError } from "@/lib/request-log";
-import { triggerResponsesEndpointSetup, waitForResponsesEndpoint } from "@/app/api/gateway/route";
+import { triggerResponsesEndpointSetup, waitForResponsesEndpoint } from "@/lib/responses-endpoint";
 
 /**
  * Streaming chat endpoint — proxies SSE from the Gateway's OpenResponses API.

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { gatewayCall, runCliCaptureBoth } from "@/lib/openclaw";
+import { CONFIG_WRITE_TIMEOUT_MS, gatewayCall, runCliCaptureBoth } from "@/lib/openclaw";
 import { gatewayConfigPatch, sanitizeConfigFile } from "@/lib/gateway-config";
 import { readFile } from "fs/promises";
 import { join } from "path";
@@ -241,7 +241,7 @@ async function applyConfigSetFallback(entries: ConfigSetEntry[]): Promise<{
       }
       const setResult = await runCliCaptureBoth(
         ["config", "set", "--strict-json", entry.path, encoded],
-        20000
+        CONFIG_WRITE_TIMEOUT_MS
       );
       if (setResult.code !== 0) {
         const details = String(setResult.stderr || setResult.stdout || "").trim();

--- a/src/app/api/gateway/route.ts
+++ b/src/app/api/gateway/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { gatewayCall } from "@/lib/openclaw";
 import { getOpenClawBin, getGatewayUrl } from "@/lib/paths";
+import { probeGatewayLiveness } from "@/lib/gateway-liveness";
 import { gatewayConfigPatch } from "@/lib/gateway-config";
 import { logRequest, logError } from "@/lib/request-log";
 import { execFile } from "child_process";
@@ -109,14 +110,7 @@ async function probeGatewayHttp(): Promise<{
 }> {
   const url = await getGatewayUrl();
   const port = parseInt(new URL(url).port, 10) || 18789;
-  try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(3000),
-    });
-    return { ok: res.ok, port, url };
-  } catch {
-    return { ok: false, port, url };
-  }
+  return { ok: await probeGatewayLiveness(url), port, url };
 }
 
 type GatewayPayload = {

--- a/src/app/api/gateway/route.ts
+++ b/src/app/api/gateway/route.ts
@@ -2,90 +2,12 @@ import { NextResponse } from "next/server";
 import { gatewayCall } from "@/lib/openclaw";
 import { getOpenClawBin, getGatewayUrl } from "@/lib/paths";
 import { probeGatewayLiveness } from "@/lib/gateway-liveness";
-import { gatewayConfigPatch } from "@/lib/gateway-config";
+import { triggerResponsesEndpointSetup } from "@/lib/responses-endpoint";
 import { logRequest, logError } from "@/lib/request-log";
 import { execFile } from "child_process";
 import { promisify } from "util";
 
 const exec = promisify(execFile);
-
-// ── Auto-enable OpenResponses endpoint for streaming chat ──
-// Uses a cooldown to avoid restart loops: once attempted (success or fail),
-// waits RETRY_COOLDOWN_MS before trying again. Never resets on failure.
-// Uses a cooldown to avoid restart loops (see issue #20).
-let _responsesEndpointEnsured = false;
-let _responsesLastAttempt = 0;
-const RESPONSES_RETRY_COOLDOWN_MS = 5 * 60_000; // 5 minutes
-
-/** Resolves when the setup attempt completes (success or fail). */
-let _responsesSetupPromise: Promise<void> | null = null;
-
-function ensureResponsesEndpoint(): void {
-  if (_responsesEndpointEnsured) return;
-  if (Date.now() - _responsesLastAttempt < RESPONSES_RETRY_COOLDOWN_MS) return;
-  _responsesLastAttempt = Date.now();
-
-  // Fire-and-forget — don't block the health check response
-  _responsesSetupPromise = (async () => {
-    try {
-      const cfg = await gatewayCall<{
-        hash?: string;
-        parsed?: Record<string, unknown>;
-        config?: Record<string, unknown>;
-      }>(
-        "config.get",
-        undefined,
-        8000,
-      );
-      // Check both parsed (standard) and config (legacy) shapes
-      const root = cfg?.parsed ?? cfg?.config ?? {};
-      const gw = (root as Record<string, unknown>)?.gateway as Record<string, unknown> | undefined;
-      const http = gw?.http as Record<string, unknown> | undefined;
-      const endpoints = http?.endpoints as Record<string, unknown> | undefined;
-      const responses = endpoints?.responses as Record<string, unknown> | undefined;
-      if (responses?.enabled === true) {
-        _responsesEndpointEnsured = true; // Already enabled, no patch needed
-        return;
-      }
-
-      await gatewayConfigPatch(
-        {
-          raw: JSON.stringify({
-            gateway: { http: { endpoints: { responses: { enabled: true } } } },
-          }),
-          baseHash: String(cfg?.hash || ""),
-          restartDelayMs: 3000,
-        },
-        10000,
-      );
-      _responsesEndpointEnsured = true;
-    } catch {
-      // Non-fatal — streaming falls back to non-streaming.
-      // Do NOT reset _responsesEndpointEnsured; cooldown timer handles retry.
-    } finally {
-      _responsesSetupPromise = null;
-    }
-  })();
-}
-
-/**
- * Wait for the in-flight responses endpoint setup to finish.
- * Called by the chat route to avoid racing with the fire-and-forget setup.
- */
-export async function waitForResponsesEndpoint(): Promise<void> {
-  if (_responsesSetupPromise) {
-    await _responsesSetupPromise;
-  }
-}
-
-/**
- * Trigger the responses endpoint setup if it hasn't been attempted yet.
- * Called by the chat route when a user sends a message before the gateway
- * health poll has fired (which normally triggers ensureResponsesEndpoint).
- */
-export function triggerResponsesEndpointSetup(): void {
-  ensureResponsesEndpoint();
-}
 
 async function runGatewayServiceCommand(
   subcommand: "restart" | "stop" | "start",
@@ -146,7 +68,7 @@ async function computeGatewayPayload(): Promise<GatewayPayload> {
   }
 
   // Gateway is alive — ensure OpenResponses endpoint is enabled for streaming chat
-  ensureResponsesEndpoint();
+  triggerResponsesEndpointSetup();
 
   // Full health call first. Status call is optional and only fetched when healthy.
   try {

--- a/src/app/api/openclaw-update/route.ts
+++ b/src/app/api/openclaw-update/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { runCli, runCliJson } from "@/lib/openclaw";
+import { CONFIG_WRITE_TIMEOUT_MS, runCli, runCliJson } from "@/lib/openclaw";
 
 const GITHUB_RELEASES_URL =
   "https://api.github.com/repos/openclaw/openclaw/releases/latest";
@@ -181,8 +181,10 @@ export async function POST(request: NextRequest) {
       if (normalizedInstalledVersion) {
         try {
           await runCli(
+            // Runs right after an update, when the new version still has to
+            // rebuild its plugin cache — the slowest `config set` there is.
             ["config", "set", "wizard.lastRunVersion", normalizedInstalledVersion],
-            8000,
+            CONFIG_WRITE_TIMEOUT_MS,
           );
           wizardLastRunVersionSynced = true;
         } catch (err) {

--- a/src/app/api/pairing/route.ts
+++ b/src/app/api/pairing/route.ts
@@ -147,14 +147,86 @@ function dedupeDmRequests(requests: DmRequest[]): DmRequest[] {
   return out;
 }
 
-async function listDmRequestsFromCli(): Promise<DmRequest[]> {
-  const result = await runCliCaptureBoth(["pairing", "list", "--json"], 10000);
-  if (result.code !== 0) {
-    const detail = String(result.stderr || result.stdout || "").trim();
-    throw new Error(detail || `pairing list exited with code ${result.code}`);
+/**
+ * Channels that can hold pairing requests, with their account ids.
+ *
+ * `openclaw pairing list` requires a channel: called without one it exits with
+ * "Channel required. Use --channel <channel> ...", which every poll wrote to the
+ * gateway log as a stack trace. Ask the gateway which channels exist and query
+ * each one; multi-account channels are queried per account so the results stay
+ * account-aware.
+ */
+async function listPairingTargets(): Promise<Array<{ channel: string; account?: string }>> {
+  const status = await gatewayCall<{
+    channels?: Record<string, unknown>;
+    channelOrder?: unknown;
+    channelAccounts?: Record<string, unknown>;
+  }>("channels.status", {}, 8000);
+
+  const channels = new Set<string>();
+  for (const key of Object.keys(status?.channels || {})) {
+    if (key.trim()) channels.add(key.trim());
   }
-  const payload = parseJsonFromCliOutput<unknown>(result.stdout, "openclaw pairing list --json");
-  return dedupeDmRequests(normalizeDmRequests(payload));
+  for (const entry of asArray(status?.channelOrder)) {
+    if (typeof entry === "string" && entry.trim()) channels.add(entry.trim());
+  }
+
+  const targets: Array<{ channel: string; account?: string }> = [];
+  for (const channel of channels) {
+    const accounts = asArray(status?.channelAccounts?.[channel])
+      .map((account) => {
+        if (typeof account === "string") return account;
+        if (isRecord(account) && typeof account.id === "string") return account.id;
+        return "";
+      })
+      .filter((id) => id.trim().length > 0);
+    if (accounts.length > 1) {
+      for (const account of accounts) targets.push({ channel, account });
+    } else {
+      targets.push({ channel });
+    }
+  }
+  return targets;
+}
+
+async function listDmRequestsFromCli(): Promise<DmRequest[]> {
+  const targets = await listPairingTargets();
+  // No channels configured means there is nothing to pair and no valid value
+  // for --channel; the filesystem scan still covers leftover pairing files.
+  if (targets.length === 0) return [];
+
+  const collected: DmRequest[] = [];
+  const failures: string[] = [];
+
+  await Promise.all(
+    targets.map(async ({ channel, account }) => {
+      const args = ["pairing", "list", "--channel", channel, "--json"];
+      if (account) args.push("--account", account);
+      const result = await runCliCaptureBoth(args, 10000);
+      if (result.code !== 0) {
+        failures.push(
+          `${channel}${account ? `/${account}` : ""}: ${String(result.stderr || result.stdout || "").trim() || `exit ${result.code}`}`,
+        );
+        return;
+      }
+      try {
+        const payload = parseJsonFromCliOutput<unknown>(
+          result.stdout,
+          `openclaw pairing list --channel ${channel} --json`,
+        );
+        collected.push(...normalizeDmRequests(payload, channel));
+      } catch (err) {
+        failures.push(`${channel}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }),
+  );
+
+  // Only fail outright when no channel answered, so one broken channel does not
+  // hide pairing requests from the others.
+  if (collected.length === 0 && failures.length === targets.length) {
+    throw new Error(`pairing list failed for all channels — ${failures.join("; ")}`);
+  }
+  return dedupeDmRequests(collected);
 }
 
 /* ── GET: list all pending requests ──────────────── */

--- a/src/app/api/skills/clawhub/route.ts
+++ b/src/app/api/skills/clawhub/route.ts
@@ -1,10 +1,30 @@
+/**
+ * ClawHub catalog — browse, search and install published skills.
+ *
+ * OpenClaw talks to the registry itself, so the catalog is reachable through
+ * the gateway: `skills.search`, `skills.detail`, `skills.install` (with
+ * `source: "clawhub"`) and `skills.update`. That is the path used here.
+ *
+ * Previously every action shelled out to a standalone `clawhub` binary, which
+ * is a separate install the dashboard cannot assume exists — when it was
+ * missing the whole tab reported `CLAWHUB_NOT_FOUND` and disabled itself. It
+ * also meant scraping slugs and versions out of a human-readable table with
+ * regexes, and installing without the gateway's trust checks.
+ *
+ * The one thing the gateway has no equivalent for is browsing without a query:
+ * `skills.search` requires one and returns nothing for the empty string. So
+ * `action=explore` still prefers the external binary, and degrades to an empty
+ * catalog with a notice rather than disabling search and install along with it.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { constants as fsConstants } from "fs";
 import { access, readFile, rm, writeFile } from "fs/promises";
 import { join } from "path";
-import { getDefaultWorkspaceSync } from "@/lib/paths";
+import { getDefaultWorkspace } from "@/lib/paths";
+import { gatewayCall } from "@/lib/openclaw";
 
 export const dynamic = "force-dynamic";
 
@@ -109,24 +129,95 @@ function parseSearch(stdout: string): SearchItem[] {
   return items;
 }
 
-function parseInstalled(stdout: string): InstalledItem[] {
-  return stripAnsi(stdout)
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const m = line.match(/^([a-z0-9][\w-]*)\s+([A-Za-z0-9._-]+)$/i);
-      if (!m) return null;
-      return {
-        slug: m[1] || "",
-        version: m[2] || "",
-      };
-    })
-    .filter((v): v is InstalledItem => Boolean(v));
-}
-
 function isValidSlug(slug: string): boolean {
   return /^[a-z0-9][a-z0-9_-]*$/i.test(slug);
+}
+
+/* ── Native registry access via the gateway ────────────────── */
+
+/** One row of `skills.search`. Registry metadata, not local skill state. */
+type RegistryHit = {
+  slug?: string;
+  displayName?: string;
+  summary?: string;
+  version?: string;
+  score?: number;
+  downloads?: number;
+  updatedAt?: number;
+  ownerHandle?: string;
+  publisher?: string;
+  official?: boolean;
+  featured?: boolean;
+  icon?: string | null;
+  install?: { kind?: string; reference?: string | null };
+  metrics?: { updatedAt?: number; rolling60DayInstalls?: number };
+  native?: {
+    skill?: { stats?: { stars?: number; downloads?: number; installs?: number } };
+    owner?: { displayName?: string; handle?: string };
+  };
+};
+
+/**
+ * Flatten a registry hit into the card shape the catalog UI renders. Stats live
+ * under `native.skill.stats` while headline counts are duplicated at the top
+ * level, so prefer the top level and fall back to the nested copy.
+ */
+function toCatalogItem(hit: RegistryHit) {
+  const stats = hit.native?.skill?.stats;
+  const slug = String(hit.slug || "");
+  const owner = hit.ownerHandle || hit.native?.owner?.handle;
+  return {
+    slug,
+    // Slugs collide across owners — "weather" resolves to several skills, and
+    // the registry answers a bare one with AMBIGUOUS_SKILL_SLUG. `@owner/slug`
+    // is the form the installer disambiguates on.
+    ref: owner && slug ? `@${owner}/${slug}` : undefined,
+    displayName: hit.displayName || undefined,
+    summary: hit.summary || "",
+    version: hit.version || "latest",
+    score: typeof hit.score === "number" ? hit.score : undefined,
+    developer: owner || hit.publisher || undefined,
+    official: Boolean(hit.official),
+    featured: Boolean(hit.featured),
+    icon: hit.icon ?? undefined,
+    installReference: hit.install?.reference ?? undefined,
+    updatedAt: hit.updatedAt ?? hit.metrics?.updatedAt ?? undefined,
+    // `stats` is the shape the explore path returns; keep both so either
+    // source renders identically.
+    stats: {
+      downloads: hit.downloads ?? stats?.downloads ?? 0,
+      installsCurrent: hit.metrics?.rolling60DayInstalls ?? stats?.installs ?? 0,
+      installsAllTime: stats?.installs ?? 0,
+      stars: stats?.stars ?? 0,
+    },
+    downloads: hit.downloads ?? stats?.downloads ?? 0,
+    stars: stats?.stars ?? 0,
+  };
+}
+
+async function nativeSearch(query: string, limit: number) {
+  const payload = await gatewayCall<{ results?: RegistryHit[] }>(
+    "skills.search",
+    { query, limit },
+    30_000,
+  );
+  return (payload?.results ?? []).map(toCatalogItem).filter((item) => item.slug);
+}
+
+/** Installed ClawHub skills, straight from the lockfile the installer writes. */
+async function nativeInstalled(): Promise<InstalledItem[]> {
+  const workspace = await getDefaultWorkspace();
+  for (const dir of [".clawhub", ".clawdhub"]) {
+    const lock = await readLockFile(join(workspace, dir, "lock.json"));
+    const entries = Object.entries(lock.skills || {});
+    if (entries.length > 0) {
+      return entries.map(([slug, meta]) => ({
+        slug,
+        version: String(meta?.version || ""),
+      }));
+    }
+  }
+  return [];
 }
 
 async function readLockFile(path: string): Promise<LockFile> {
@@ -152,7 +243,7 @@ async function uninstallWorkspaceSkill(slug: string): Promise<{
   removedDir: boolean;
   removedLock: boolean;
 }> {
-  const workspace = getDefaultWorkspaceSync();
+  const workspace = await getDefaultWorkspace();
   const skillDir = join(workspace, "skills", slug);
   const lockPath = join(workspace, ".clawhub", "lock.json");
 
@@ -184,7 +275,7 @@ function shellEscape(arg: string): string {
 }
 
 async function runClawHub(args: string[], timeout = 30000): Promise<{ stdout: string; stderr: string }> {
-  const workspace = getDefaultWorkspaceSync();
+  const workspace = await getDefaultWorkspace();
   const fullArgs = ["--no-input", "--workdir", workspace, ...args];
   // Spawn through a login shell so the user's PATH (from ~/.zshrc, ~/.bash_profile, etc.)
   // is available — fixes "clawhub not found" when the Next.js process has a limited env.
@@ -207,34 +298,84 @@ export async function GET(request: NextRequest) {
       const q = (searchParams.get("q") || "").trim();
       const limit = clamp(Number(searchParams.get("limit") || 24), 1, 50);
       if (!q) return NextResponse.json({ items: [] });
-      const { stdout } = await runClawHub(["search", q, "--limit", String(limit)], 30000);
-      return NextResponse.json({ items: parseSearch(stdout) });
+      try {
+        return NextResponse.json({ items: await nativeSearch(q, limit) });
+      } catch (rpcErr) {
+        try {
+          const { stdout } = await runClawHub(["search", q, "--limit", String(limit)], 30000);
+          return NextResponse.json({
+            items: parseSearch(stdout),
+            warning: `skills.search unavailable (${String(rpcErr)}); used the clawhub CLI.`,
+          });
+        } catch (cliErr) {
+          // Report why the gateway refused, not that the optional CLI is
+          // absent — the former is the actionable failure.
+          throw isClawhubNotFound(cliErr) ? rpcErr : cliErr;
+        }
+      }
     }
 
     if (action === "list") {
-      const { stdout } = await runClawHub(["list"], 10000);
-      return NextResponse.json({ items: parseInstalled(stdout) });
+      return NextResponse.json({ items: await nativeInstalled() });
     }
 
     if (action === "inspect") {
       const slug = (searchParams.get("slug") || "").trim();
       if (!slug) return NextResponse.json({ error: "slug required" }, { status: 400 });
-      const version = (searchParams.get("version") || "").trim();
-      const args = ["inspect", slug, "--json"];
-      if (version) args.push("--version", version);
-      const { stdout } = await runClawHub(args, 20000);
-      const parsed = parseLooseJson<Record<string, unknown>>(stdout);
-      return NextResponse.json(parsed || { ok: false, raw: stdout });
+      try {
+        // `skills.detail` is keyed by slug alone — it always describes the
+        // latest published version.
+        return NextResponse.json(
+          await gatewayCall<Record<string, unknown>>("skills.detail", { slug }, 20_000),
+        );
+      } catch (rpcErr) {
+        try {
+          const version = (searchParams.get("version") || "").trim();
+          const args = ["inspect", slug, "--json"];
+          if (version) args.push("--version", version);
+          const { stdout } = await runClawHub(args, 20000);
+          const parsed = parseLooseJson<Record<string, unknown>>(stdout);
+          return NextResponse.json(
+            parsed
+              ? { ...parsed, warning: `skills.detail unavailable (${String(rpcErr)}); used the clawhub CLI.` }
+              : { ok: false, raw: stdout },
+          );
+        } catch (cliErr) {
+          // A bare slug several owners publish comes back as
+          // AMBIGUOUS_SKILL_SLUG listing the qualified refs. Surface that
+          // rather than blaming a missing optional CLI.
+          throw isClawhubNotFound(cliErr) ? rpcErr : cliErr;
+        }
+      }
     }
 
+    // Browse without a query. No gateway equivalent, so this is the one action
+    // that still needs the standalone CLI.
     const limit = clamp(Number(searchParams.get("limit") || 24), 1, 100);
     const sort = (searchParams.get("sort") || "trending").trim();
-    const { stdout } = await runClawHub(["explore", "--limit", String(limit), "--sort", sort, "--json"], 30000);
-    const parsed = parseLooseJson<ExplorePayload>(stdout);
-    return NextResponse.json({
-      items: parsed?.items || [],
-      nextCursor: parsed?.nextCursor || null,
-    });
+    try {
+      const { stdout } = await runClawHub(
+        ["explore", "--limit", String(limit), "--sort", sort, "--json"],
+        30000,
+      );
+      const parsed = parseLooseJson<ExplorePayload>(stdout);
+      return NextResponse.json({
+        items: parsed?.items || [],
+        nextCursor: parsed?.nextCursor || null,
+      });
+    } catch (err) {
+      if (!isClawhubNotFound(err)) throw err;
+      // Report an empty catalog rather than CLAWHUB_NOT_FOUND: search, install
+      // and update all work without the binary, and that code makes the client
+      // disable them.
+      return NextResponse.json({
+        items: [],
+        nextCursor: null,
+        browseUnavailable: true,
+        notice:
+          "Browsing the catalog needs the standalone `clawhub` CLI. Search for a skill by name to install it without one.",
+      });
+    }
   } catch (err) {
     if (isClawhubNotFound(err)) {
       return NextResponse.json(
@@ -266,27 +407,55 @@ export async function POST(request: NextRequest) {
     const version = (body.version as string | undefined)?.trim();
 
     if (action === "install") {
-      if (!slug) return NextResponse.json({ error: "slug required" }, { status: 400 });
+      const ref = (body.ref as string | undefined)?.trim();
+      // Prefer the owner-qualified `@owner/slug`: a bare slug that several
+      // owners publish is rejected by the registry as ambiguous.
+      const target = ref || slug;
+      if (!target) return NextResponse.json({ error: "slug or ref required" }, { status: 400 });
       const force = Boolean(body.force);
-      const args = ["install", slug];
-      if (version) args.push("--version", version);
-      if (force) args.push("--force");
-      const { stdout, stderr } = await runClawHub(args, 120000);
-      return NextResponse.json({ ok: true, action, slug, output: `${stdout}${stderr}`.trim() });
+      // `force` doubles as the client's "install it anyway" answer to a trust
+      // warning, which is a separate acknowledgement on this API.
+      const result = await gatewayCall<{
+        ok?: boolean;
+        message?: string;
+        slug?: string;
+        version?: string;
+        warning?: string;
+      }>(
+        "skills.install",
+        {
+          source: "clawhub",
+          slug: target,
+          ...(version ? { version } : {}),
+          ...(force ? { force: true, acknowledgeClawHubRisk: true } : {}),
+        },
+        120_000,
+      );
+      return NextResponse.json({
+        ok: true,
+        action,
+        slug: result.slug ?? slug,
+        version: result.version,
+        output: [result.message, result.warning].filter(Boolean).join("\n"),
+      });
     }
 
     if (action === "update") {
-      if (!slug) {
-        const args = ["update", "--all"];
-        if (body.force) args.push("--force");
-        const { stdout, stderr } = await runClawHub(args, 120000);
-        return NextResponse.json({ ok: true, action, slug: null, output: `${stdout}${stderr}`.trim() });
-      }
-      const args = ["update", slug];
-      if (version) args.push("--version", version);
-      if (body.force) args.push("--force");
-      const { stdout, stderr } = await runClawHub(args, 120000);
-      return NextResponse.json({ ok: true, action, slug: slug || null, output: `${stdout}${stderr}`.trim() });
+      const result = await gatewayCall<{ message?: string; ok?: boolean }>(
+        "skills.update",
+        {
+          source: "clawhub",
+          ...(slug ? { slug } : { all: true }),
+          ...(body.force ? { acknowledgeClawHubRisk: true } : {}),
+        },
+        120_000,
+      );
+      return NextResponse.json({
+        ok: true,
+        action,
+        slug: slug || null,
+        output: result.message || "",
+      });
     }
 
     if (action === "uninstall") {

--- a/src/app/api/skills/install/route.ts
+++ b/src/app/api/skills/install/route.ts
@@ -1,111 +1,121 @@
 import { NextRequest } from "next/server";
-import { spawn } from "child_process";
+import { gatewayCall } from "@/lib/openclaw";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 300; // 5 minutes for long installs
+export const maxDuration = 300; // Installs can be slow (compiling formulae, etc).
 
 /**
  * POST /api/skills/install
  *
- * Streams live terminal output from an install command (brew, npm, etc).
- * Returns Server-Sent Events with { type, text } payloads.
+ * Installs a skill's missing requirement through the gateway and streams the
+ * result back as Server-Sent Events: `{ type: "stdout" | "stderr" | "exit" |
+ * "error", ... }`.
  *
- * Body: { kind: "brew" | "npm", package: string }
+ * Body: { name: string, installId: string }
+ *   name      — skill name, as reported by /api/skills
+ *   installId — id of the entry in that skill's `install` array
+ *
+ * This delegates to the gateway's `skills.install` rather than running a
+ * package manager here, for three reasons:
+ *
+ *   1. The package name is not ours to guess. A skill's install spec carries a
+ *      `formula`/`package` distinct from the binaries it provides — 1password's
+ *      brew spec is `formula: "1password-cli"` providing `bins: ["op"]`. The
+ *      inventory API deliberately omits those fields, so a client that builds
+ *      its own command installs the wrong thing.
+ *   2. OpenClaw picks the installer per host — Homebrew, `uv`, the configured
+ *      node manager, `go`, then a direct download — honouring
+ *      `skills.install.preferBrew` and `skills.install.nodeManager`. Hardcoding
+ *      brew/npm/pip fails outright on a Linux or Docker deployment.
+ *   3. The binary has to land on the gateway's host, which is where the agent
+ *      will look for it. That is not necessarily this host.
+ *
+ * The trade-off is that `skills.install` answers once when it finishes instead
+ * of streaming, so output arrives in one batch. The SSE envelope is kept so the
+ * client renders it the same way either path is taken.
  */
-export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const kind = body.kind as string;
-  const pkg = body.package as string;
 
-  if (!pkg) {
+type SkillsInstallResult = {
+  ok?: boolean;
+  message?: string;
+  stdout?: string;
+  stderr?: string;
+  code?: number | null;
+  warnings?: string[];
+};
+
+const INSTALL_TIMEOUT_MS = 285_000;
+
+function sse(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => ({}));
+  const name = typeof body?.name === "string" ? body.name.trim() : "";
+  const installId = typeof body?.installId === "string" ? body.installId.trim() : "";
+
+  if (!name || !installId) {
     return new Response(
-      JSON.stringify({ error: "package required" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
+      JSON.stringify({ error: "name and installId are required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
     );
   }
 
-  // Build command based on kind
-  let cmd: string;
-  let args: string[];
-
-  switch (kind) {
-    case "brew":
-      cmd = "brew";
-      args = ["install", "--verbose", pkg];
-      break;
-    case "npm":
-      cmd = "npm";
-      args = ["install", "-g", pkg];
-      break;
-    case "pip":
-      cmd = "pip3";
-      args = ["install", pkg];
-      break;
-    default:
-      return new Response(
-        JSON.stringify({ error: `Unsupported install kind: ${kind}` }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
-      );
-  }
+  const agentId =
+    typeof body?.agentId === "string" && body.agentId.trim()
+      ? body.agentId.trim()
+      : undefined;
 
   const encoder = new TextEncoder();
-
   const stream = new ReadableStream({
-    start(controller) {
-      // Send initial banner
-      const banner = `\x1b[1;36m$ ${cmd} ${args.join(" ")}\x1b[0m\n`;
-      controller.enqueue(
-        encoder.encode(`data: ${JSON.stringify({ type: "stdout", text: banner })}\n\n`)
-      );
-
-      const child = spawn(cmd, args, {
-        env: { ...process.env, NO_COLOR: "0", HOMEBREW_COLOR: "1", OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: "1" },
-        timeout: 240000,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-
-      child.stdout.on("data", (data: Buffer) => {
-        const text = data.toString();
+    async start(controller) {
+      const send = (payload: unknown) => {
         try {
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify({ type: "stdout", text })}\n\n`)
-          );
-        } catch { /* stream closed */ }
+          controller.enqueue(encoder.encode(sse(payload)));
+        } catch {
+          // Client disconnected.
+        }
+      };
+
+      send({
+        type: "stdout",
+        text: `\x1b[1;36m$ openclaw skills install ${name} (${installId})\x1b[0m\n`,
       });
 
-      child.stderr.on("data", (data: Buffer) => {
-        const text = data.toString();
-        try {
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify({ type: "stderr", text })}\n\n`)
-          );
-        } catch { /* stream closed */ }
-      });
+      try {
+        const result = await gatewayCall<SkillsInstallResult>(
+          "skills.install",
+          {
+            name,
+            installId,
+            timeoutMs: INSTALL_TIMEOUT_MS,
+            ...(agentId ? { agentId } : {}),
+          },
+          INSTALL_TIMEOUT_MS,
+        );
 
-      child.on("close", (code) => {
-        try {
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ type: "exit", code: code ?? 1 })}\n\n`
-            )
-          );
-          controller.close();
-        } catch { /* stream closed */ }
-      });
+        for (const warning of result.warnings ?? []) {
+          send({ type: "stderr", text: `${warning}\n` });
+        }
+        if (result.stdout) send({ type: "stdout", text: result.stdout });
+        if (result.stderr) send({ type: "stderr", text: result.stderr });
+        if (result.message) {
+          send({
+            type: result.ok ? "stdout" : "stderr",
+            text: `${result.message}\n`,
+          });
+        }
+        send({ type: "exit", code: result.ok ? 0 : (result.code ?? 1) });
+      } catch (err) {
+        send({ type: "error", text: String(err) });
+      }
 
-      child.on("error", (err) => {
-        try {
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ type: "error", text: String(err) })}\n\n`
-            )
-          );
-          controller.close();
-        } catch { /* stream closed */ }
-      });
-
-      // Close stdin immediately
-      child.stdin.end();
+      try {
+        controller.close();
+      } catch {
+        // Already closed.
+      }
     },
   });
 

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -372,7 +372,6 @@ export async function POST(request: NextRequest) {
 
       case "enable-skill":
       case "disable-skill": {
-        // Toggle skill via skills.entries.<name>.enabled
         const name = body.name as string;
         if (!name)
           return NextResponse.json(
@@ -380,19 +379,30 @@ export async function POST(request: NextRequest) {
             { status: 400 }
           );
 
-        const enabling = action === "enable-skill";
+        const enabled = action === "enable-skill";
 
+        // `skills.update` is the purpose-built toggle: it writes the same
+        // `skills.entries.<key>.enabled` and takes effect immediately. Writing
+        // that key through config.patch instead needed a gateway restart to be
+        // picked up, which dropped every live session to flip one switch.
         try {
-          await patchConfig({
-            skills: {
-              entries: {
-                [name]: { enabled: enabling },
-              },
-            },
-          }, { restartDelayMs: 2000 });
+          await gatewayCall("skills.update", { skillKey: name, enabled }, 15_000);
           return NextResponse.json({ ok: true, action, name });
-        } catch (err) {
-          return NextResponse.json({ error: String(err) }, { status: 500 });
+        } catch (rpcErr) {
+          // Fall back to the config write for gateways without the method.
+          try {
+            await patchConfig({
+              skills: { entries: { [name]: { enabled } } },
+            }, { restartDelayMs: 2000 });
+            return NextResponse.json({
+              ok: true,
+              action,
+              name,
+              warning: `skills.update unavailable (${rpcErr instanceof Error ? rpcErr.message : String(rpcErr)}); wrote the config and restarted the gateway instead.`,
+            });
+          } catch (err) {
+            return NextResponse.json({ error: String(err) }, { status: 500 });
+          }
         }
       }
 

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchConfig, patchConfig } from "@/lib/gateway-config";
+import { gatewayCall } from "@/lib/openclaw";
 import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { getDefaultWorkspaceSync, getSystemSkillsDir } from "@/lib/paths";
@@ -338,36 +339,34 @@ export async function POST(request: NextRequest) {
     const action = body.action as string;
 
     switch (action) {
-      case "install-brew": {
-        // Install a binary dependency via brew
-        const pkg = body.package as string;
-        if (!pkg)
+      // Non-streaming counterpart of POST /api/skills/install. Both go through
+      // the gateway so OpenClaw resolves the package name and the installer for
+      // its own host; see that route for why doing it here is wrong.
+      case "install-requirement": {
+        const name = body.name as string;
+        const installId = body.installId as string;
+        if (!name || !installId) {
           return NextResponse.json(
-            { error: "package required" },
+            { error: "name and installId required" },
             { status: 400 }
           );
-        // Run brew install
-        const { execFile } = await import("child_process");
-        const { promisify } = await import("util");
-        const exec = promisify(execFile);
+        }
         try {
-          const { stdout, stderr } = await exec("brew", ["install", pkg], {
-            timeout: 120000,
-          });
-          return NextResponse.json({
-            ok: true,
-            action,
-            package: pkg,
-            output: stdout + stderr,
-          });
-        } catch (err: unknown) {
-          const e = err as { stderr?: string; message?: string };
-          return NextResponse.json(
-            {
-              error: `brew install failed: ${e.stderr || e.message || String(err)}`,
-            },
-            { status: 500 }
-          );
+          const result = await gatewayCall<{
+            ok?: boolean;
+            message?: string;
+            stdout?: string;
+            stderr?: string;
+          }>("skills.install", { name, installId }, 285_000);
+          if (!result?.ok) {
+            return NextResponse.json(
+              { error: result?.message || "install failed", ...result },
+              { status: 500 }
+            );
+          }
+          return NextResponse.json({ ok: true, action, name, installId, ...result });
+        } catch (err) {
+          return NextResponse.json({ error: String(err) }, { status: 500 });
         }
       }
 

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { runCliJson } from "@/lib/openclaw";
 import { fetchConfig, patchConfig } from "@/lib/gateway-config";
 import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { getDefaultWorkspaceSync, getSystemSkillsDir } from "@/lib/paths";
+import {
+  deriveSkillsCheck,
+  findSkillRow,
+  loadSkillsInventory,
+  type SkillsStatus,
+  type SkillStatusRow,
+} from "@/lib/skills-status";
 
 export const dynamic = "force-dynamic";
 
@@ -34,53 +40,7 @@ type SkillsList = {
   skills: Skill[];
 };
 
-type SkillsCheck = {
-  summary: {
-    total: number;
-    eligible: number;
-    disabled: number;
-    blocked: number;
-    missingRequirements: number;
-  };
-  eligible: string[];
-  disabled: string[];
-  blocked: string[];
-  missingRequirements: { name: string; missing: string[] }[];
-};
-
-type SkillDetail = {
-  name: string;
-  description: string;
-  source: string;
-  bundled: boolean;
-  filePath: string;
-  baseDir: string;
-  skillKey: string;
-  emoji?: string;
-  homepage?: string;
-  always: boolean;
-  disabled: boolean;
-  blockedByAllowlist: boolean;
-  eligible: boolean;
-  requirements: {
-    bins: string[];
-    anyBins: string[];
-    env: string[];
-    config: string[];
-    os: string[];
-  };
-  missing: {
-    bins: string[];
-    anyBins: string[];
-    env: string[];
-    config: string[];
-    os: string[];
-  };
-  configChecks: unknown[];
-  install: { id: string; kind: string; label: string; bins?: string[] }[];
-};
-
-/* ── Filesystem fallback for when CLI returns empty output ────── */
+/* ── Filesystem fallback for when neither gateway nor CLI answers ────── */
 
 /**
  * Parse SKILL.md frontmatter to extract metadata.
@@ -174,50 +134,38 @@ async function readSkillsFromFilesystem(): Promise<SkillsList> {
 
 /* ── GET ──────────────────────────────────────────── */
 
+/** Project one inventory row onto the list shape the UI consumes. */
+function toListSkill(row: SkillStatusRow): Skill {
+  return {
+    name: row.name,
+    description: row.description,
+    emoji: row.emoji || "",
+    eligible: row.eligible,
+    disabled: row.disabled,
+    blockedByAllowlist: row.blockedByAllowlist,
+    source: row.source,
+    bundled: row.bundled,
+    homepage: row.homepage,
+    missing: row.missing ?? { bins: [], anyBins: [], env: [], config: [], os: [] },
+  };
+}
+
+function toListPayload(status: SkillsStatus): SkillsList {
+  return {
+    workspaceDir: status.workspaceDir,
+    managedSkillsDir: status.managedSkillsDir,
+    skills: status.skills.map(toListSkill),
+  };
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const action = searchParams.get("action") || "list";
+  // Must be a real id from agents.list; the gateway rejects an unknown one
+  // rather than falling back to the default agent.
+  const agentId = searchParams.get("agent")?.trim() || undefined;
 
   try {
-    if (action === "check") {
-      const data = await runCliJson<SkillsCheck>(["skills", "check"]);
-      return NextResponse.json(data);
-    }
-
-    if (action === "info") {
-      const name = searchParams.get("name");
-      if (!name)
-        return NextResponse.json({ error: "name required" }, { status: 400 });
-
-      const data = await runCliJson<SkillDetail>(["skills", "info", name]);
-
-      // Try to read the SKILL.md content for display
-      let skillMd: string | null = null;
-      if (data.filePath) {
-        try {
-          const raw = await readFile(data.filePath, "utf-8");
-          // Truncate very long files
-          skillMd = raw.length > 10000 ? raw.slice(0, 10000) + "\n\n...(truncated)" : raw;
-        } catch {
-          // file may not be readable
-        }
-      }
-
-      // Check the config for skill-specific settings
-      let skillConfig: Record<string, unknown> | null = null;
-      try {
-        const configData = await fetchConfig(8000);
-        const tools = (configData.resolved.tools || {}) as Record<string, unknown>;
-        if (tools[data.skillKey || data.name]) {
-          skillConfig = tools[data.skillKey || data.name] as Record<string, unknown>;
-        }
-      } catch {
-        // config not available
-      }
-
-      return NextResponse.json({ ...data, skillMd, skillConfig });
-    }
-
     if (action === "config") {
       // Get the full config to see skills/tools section
       try {
@@ -245,38 +193,95 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Default: list all skills
-    const data = await runCliJson<SkillsList>(["skills", "list"]);
-    return NextResponse.json(data);
+    if (action === "info" && !searchParams.get("name")) {
+      return NextResponse.json({ error: "name required" }, { status: 400 });
+    }
+
+    // One inventory snapshot answers list, check and info alike: every row
+    // carries the full `skills info` field set, so opening a skill costs no
+    // extra call.
+    const { status, warning } = await loadSkillsInventory(agentId);
+
+    if (action === "check") {
+      return NextResponse.json({ ...deriveSkillsCheck(status), warning });
+    }
+
+    if (action === "info") {
+      const name = searchParams.get("name") as string;
+      const row = findSkillRow(status, name);
+      if (!row) {
+        return NextResponse.json(
+          { error: `Unknown skill: ${name}` },
+          { status: 404 },
+        );
+      }
+
+      // Read SKILL.md for display. The list-only CLI fallback has no filePath,
+      // so this is best-effort.
+      let skillMd: string | null = null;
+      if (row.filePath) {
+        try {
+          const raw = await readFile(row.filePath, "utf-8");
+          skillMd = raw.length > 10000 ? raw.slice(0, 10000) + "\n\n...(truncated)" : raw;
+        } catch {
+          // File may live outside this host, or be unreadable.
+        }
+      }
+
+      let skillConfig: Record<string, unknown> | null = null;
+      try {
+        const configData = await fetchConfig(8000);
+        const tools = (configData.resolved.tools || {}) as Record<string, unknown>;
+        const key = row.skillKey || row.name;
+        if (tools[key]) skillConfig = tools[key] as Record<string, unknown>;
+      } catch {
+        // Config is optional context for the detail view.
+      }
+
+      return NextResponse.json({ ...row, skillMd, skillConfig, warning });
+    }
+
+    return NextResponse.json({ ...toListPayload(status), warning });
   } catch (err) {
     console.error("Skills API error:", err);
 
-    // Filesystem fallback — read skills directly from disk when CLI fails.
-    // This handles the no-TTY empty stdout issue in OpenClaw v2026.3.23+.
+    // Last resort: read SKILL.md files off disk. Loses eligibility and
+    // requirement state, but beats showing an empty Skills page when neither
+    // the gateway nor the CLI can be reached.
     if (action === "list" || action === "check") {
       try {
         const fsSkills = await readSkillsFromFilesystem();
         if (fsSkills.skills.length > 0) {
           if (action === "check") {
             return NextResponse.json({
+              workspaceDir: fsSkills.workspaceDir,
+              managedSkillsDir: fsSkills.managedSkillsDir,
               summary: {
                 total: fsSkills.skills.length,
                 eligible: 0,
+                modelVisible: 0,
+                commandVisible: 0,
                 disabled: 0,
                 blocked: 0,
+                agentFiltered: 0,
+                notInjected: 0,
                 missingRequirements: 0,
               },
               eligible: [],
+              modelVisible: [],
+              commandVisible: [],
               disabled: [],
               blocked: [],
+              agentFiltered: [],
+              notInjected: [],
               missingRequirements: [],
-              warning: "Loaded from filesystem (CLI unavailable)",
+              warning: "Loaded from filesystem — gateway and CLI both unreachable, so eligibility is unknown.",
               fromFilesystem: true,
             });
           }
           return NextResponse.json({
             ...fsSkills,
-            warning: "Loaded from filesystem (CLI unavailable)",
+            warning: "Loaded from filesystem — gateway and CLI both unreachable, so eligibility is unknown.",
             fromFilesystem: true,
           });
         }
@@ -287,16 +292,26 @@ export async function GET(request: NextRequest) {
 
     if (action === "check") {
       return NextResponse.json({
+        workspaceDir: "",
+        managedSkillsDir: "",
         summary: {
           total: 0,
           eligible: 0,
+          modelVisible: 0,
+          commandVisible: 0,
           disabled: 0,
           blocked: 0,
+          agentFiltered: 0,
+          notInjected: 0,
           missingRequirements: 0,
         },
         eligible: [],
+        modelVisible: [],
+        commandVisible: [],
         disabled: [],
         blocked: [],
+        agentFiltered: [],
+        notInjected: [],
         missingRequirements: [],
         warning: String(err),
         degraded: true,

--- a/src/app/api/skills/test/route.ts
+++ b/src/app/api/skills/test/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { runCli } from "@/lib/openclaw";
 import { runOpenResponsesText } from "@/lib/openresponses";
+import { getDefaultAgentId } from "@/lib/paths";
 
 export const dynamic = "force-dynamic";
 
@@ -31,7 +32,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const agentId = safeToken(body.agentId || "", "main");
+    // "main" is a mainKey alias, not an agent id: the RPC rejects it and the CLI
+    // resolves `--agent main` to a workspace inside the real one. Resolve the
+    // real default instead, keeping "main" only for an unreachable gateway.
+    const agentId = safeToken(
+      body.agentId || (await getDefaultAgentId()) || "",
+      "main",
+    );
     if (!agentId) {
       return NextResponse.json(
         { ok: false, error: "Invalid agentId" },

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getGatewayUrl } from "@/lib/paths";
+import { probeGatewayLiveness } from "@/lib/gateway-liveness";
 import { resolveTransport } from "@/lib/openclaw";
 
 export const dynamic = "force-dynamic";
@@ -51,8 +52,7 @@ export async function GET() {
     let gateway: "online" | "offline" | "degraded" = "offline";
 
     try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
-      gateway = res.ok ? "online" : "degraded";
+      gateway = (await probeGatewayLiveness(url)) ? "online" : "degraded";
     } catch {
       // unreachable — gateway stays "offline"
     }

--- a/src/app/api/subagents/route.ts
+++ b/src/app/api/subagents/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { gatewayCall } from "@/lib/openclaw";
+import { getDefaultAgentId } from "@/lib/paths";
 
 type GatewayMessage = {
   role?: string;
@@ -207,7 +208,12 @@ function defaultSessionKey(agentId: string): string {
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    const agentId = sanitizeArg(searchParams.get("agentId") || "main", 64);
+    // "main" is a mainKey alias rather than an agent id — the CLI accepts it and
+    // silently targets a workspace inside the real one — so resolve the default.
+    const agentId = sanitizeArg(
+      searchParams.get("agentId") || (await getDefaultAgentId()) || "main",
+      64,
+    );
     const sessionKey = sanitizeArg(searchParams.get("sessionKey") || defaultSessionKey(agentId), 200);
     const out = await runAgentMessage({
       agentId,
@@ -229,7 +235,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const action = sanitizeArg(body?.action, 24).toLowerCase();
-    const agentId = sanitizeArg(body?.agentId || "main", 64);
+    const agentId = sanitizeArg(body?.agentId || (await getDefaultAgentId()) || "main", 64);
     const sessionKey = sanitizeArg(body?.sessionKey || defaultSessionKey(agentId), 200);
     const waitTimeoutMs = Number(body?.waitTimeoutMs || 120000);
     const thinking = sanitizeArg(body?.thinking || "minimal", 16);

--- a/src/components/skills-view.tsx
+++ b/src/components/skills-view.tsx
@@ -209,14 +209,14 @@ function ToastBar({ toast, onDone }: { toast: Toast; onDone: () => void }) {
 type TermLine = { text: string; stream: "stdout" | "stderr" | "system" };
 
 function InstallTerminal({
-  kind,
-  pkg,
+  skillName,
+  installId,
   label,
   onDone,
   onClose,
 }: {
-  kind: string;
-  pkg: string;
+  skillName: string;
+  installId: string;
   label: string;
   onDone: (ok: boolean) => void;
   onClose: () => void;
@@ -257,7 +257,7 @@ function InstallTerminal({
         const res = await fetch("/api/skills/install", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ kind, package: pkg }),
+          body: JSON.stringify({ name: skillName, installId }),
           signal: controller.signal,
         });
 
@@ -331,7 +331,7 @@ function InstallTerminal({
 
     return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [kind, pkg]);
+  }, [skillName, installId]);
 
   const handleAbort = useCallback(() => {
     abortRef.current?.abort();
@@ -359,7 +359,7 @@ function InstallTerminal({
           <div className="flex items-center gap-2">
             <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
             <span className="text-xs font-medium text-muted-foreground">
-              {kind} install {pkg}
+              skills install {skillName} ({installId})
             </span>
           </div>
           {running && (
@@ -711,7 +711,7 @@ function SkillDetailPanel({ name, onBack, onAction }: { name: string; onBack: ()
   const [busy, setBusy] = useState<string | null>(null);
   const [showMd, setShowMd] = useState(false);
   const [showTechnicalDetails, setShowTechnicalDetails] = useState(false);
-  const [installTerminal, setInstallTerminal] = useState<{ kind: string; pkg: string; label: string } | null>(null);
+  const [installTerminal, setInstallTerminal] = useState<{ installId: string; label: string } | null>(null);
   const installSectionRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -889,41 +889,33 @@ function SkillDetailPanel({ name, onBack, onAction }: { name: string; onBack: ()
           <div ref={installSectionRef} className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4 space-y-3">
             <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-300"><Download className="h-3.5 w-3.5" />Install what’s missing</h3>
             <p className="text-xs text-amber-800/90 dark:text-amber-200/90">This skill needs the following to work. Click Install to add them (when available).</p>
-            <div className="space-y-2">{detail.install.map((inst) => {
-              const supportedKinds = ["brew", "npm", "pip"];
-              const canInstall = supportedKinds.includes(inst.kind) && inst.bins && inst.bins.length > 0;
-              return (
+            <div className="space-y-2">{detail.install.map((inst) => (
                 <div key={inst.id} className="glass-subtle flex items-center justify-between rounded-lg px-4 py-3">
                   <div>
                     <p className="text-xs font-medium text-foreground/90">{inst.label}</p>
                     <p className="text-xs text-muted-foreground">{inst.kind}{inst.bins ? " \u2022 installs " + inst.bins.join(", ") : ""}</p>
                   </div>
-                  {canInstall ? (
-                    <button
-                      onClick={() => setInstallTerminal({ kind: inst.kind, pkg: inst.bins![0], label: inst.label })}
-                      disabled={installTerminal !== null}
-                      className="flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted disabled:opacity-50"
-                    >
-                      <Terminal className="h-3 w-3" />Install
-                    </button>
-                  ) : (
-                    <span className="rounded bg-muted px-2 py-1 text-xs text-muted-foreground">Manual</span>
-                  )}
+                  <button
+                    onClick={() => setInstallTerminal({ installId: inst.id, label: inst.label })}
+                    disabled={installTerminal !== null}
+                    className="flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted disabled:opacity-50"
+                  >
+                    <Terminal className="h-3 w-3" />Install
+                  </button>
                 </div>
-              );
-            })}</div>
+              ))}</div>
           </div>
         )}
 
         {/* Install terminal */}
         {installTerminal && (
           <InstallTerminal
-            kind={installTerminal.kind}
-            pkg={installTerminal.pkg}
+            skillName={name}
+            installId={installTerminal.installId}
             label={installTerminal.label}
             onDone={(ok) => {
               if (ok) {
-                onAction(`${installTerminal.pkg} installed successfully`);
+                onAction(`${installTerminal.label} completed`);
                 // Refresh skill detail
                 fetch("/api/skills?action=info&name=" + encodeURIComponent(name))
                   .then((r) => r.json())

--- a/src/components/skills-view.tsx
+++ b/src/components/skills-view.tsx
@@ -96,12 +96,31 @@ const SKILL_ORIGIN_ORDER: SkillOrigin[] = ["bundled", "workspace", "shared", "ot
 
 /* ── Helpers ────────────────────────────────────── */
 
-function hasMissing(m: Missing): boolean {
-  return m.bins.length > 0 || m.anyBins.length > 0 || m.env.length > 0 || m.config.length > 0 || m.os.length > 0;
+const NO_REQUIREMENTS: Missing = { bins: [], anyBins: [], env: [], config: [], os: [] };
+
+/**
+ * Requirement bags are optional on the wire — a degraded filesystem read has no
+ * eligibility data — so treat a missing bag as empty rather than throwing while
+ * rendering.
+ */
+function requirementBag(m: Missing | undefined | null): Missing {
+  if (!m) return NO_REQUIREMENTS;
+  return {
+    bins: m.bins ?? [],
+    anyBins: m.anyBins ?? [],
+    env: m.env ?? [],
+    config: m.config ?? [],
+    os: m.os ?? [],
+  };
 }
 
-function missingCount(m: Missing): number {
-  return m.bins.length + m.anyBins.length + m.env.length + m.config.length + m.os.length;
+function hasMissing(m: Missing | undefined | null): boolean {
+  return missingCount(m) > 0;
+}
+
+function missingCount(m: Missing | undefined | null): number {
+  const bag = requirementBag(m);
+  return bag.bins.length + bag.anyBins.length + bag.env.length + bag.config.length + bag.os.length;
 }
 
 function getAvailability(skill: Pick<Skill, "eligible" | "missing" | "blockedByAllowlist">): {
@@ -711,8 +730,23 @@ function SkillCard({ skill, onClick, onToggle, toggling }: { skill: Skill; onCli
 
 /* ── Skill Detail Panel ─────────────────────────── */
 
+/**
+ * Reason this payload cannot be rendered as a skill, or null when it can.
+ * Covers both an explicit `{ error }` body and a 200 whose shape is unusable.
+ */
+function readDetailError(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return "Malformed response from /api/skills.";
+  const record = payload as Record<string, unknown>;
+  if (typeof record.error === "string" && record.error.trim()) return record.error;
+  if (typeof record.name !== "string" || !record.name.trim()) {
+    return "The skill inventory is unavailable, so this skill's details could not be loaded.";
+  }
+  return null;
+}
+
 function SkillDetailPanel({ name, onBack, onAction }: { name: string; onBack: () => void; onAction: (msg: string) => void }) {
   const [detail, setDetail] = useState<SkillDetail | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [showMd, setShowMd] = useState(false);
@@ -722,10 +756,25 @@ function SkillDetailPanel({ name, onBack, onAction }: { name: string; onBack: ()
 
   useEffect(() => {
     setLoading(true);
+    setDetailError(null);
     fetch("/api/skills?action=info&name=" + encodeURIComponent(name))
       .then((r) => r.json())
-      .then((d) => { setDetail(d); setLoading(false); })
-      .catch(() => setLoading(false));
+      .then((d) => {
+        // An error payload is still an object, so storing it unchecked used to
+        // pass the null guard below and then crash on `detail.missing.bins`.
+        const err = readDetailError(d);
+        if (err) {
+          setDetail(null);
+          setDetailError(err);
+        } else {
+          setDetail(d as SkillDetail);
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        setDetailError(String(err));
+        setLoading(false);
+      });
   }, [name]);
 
   const doAction = useCallback(async (action: string, params: Record<string, unknown>) => {
@@ -736,11 +785,12 @@ function SkillDetailPanel({ name, onBack, onAction }: { name: string; onBack: ()
       if (d.ok) { onAction(action + " succeeded"); } else { onAction("Error: " + (d.error || "failed")); }
     } catch (err) { onAction("Error: " + String(err)); }
     finally { setBusy(null); }
-    // Refresh detail
+    // Refresh detail. Keep the previous snapshot on a bad payload rather than
+    // replacing a rendered skill with something unrenderable.
     try {
       const res = await fetch("/api/skills?action=info&name=" + encodeURIComponent(name));
       const d = await res.json();
-      setDetail(d);
+      if (!readDetailError(d)) setDetail(d as SkillDetail);
     } catch { /* ignore */ }
   }, [name, onAction]);
 
@@ -748,6 +798,24 @@ function SkillDetailPanel({ name, onBack, onAction }: { name: string; onBack: ()
     return (
       <SectionLayout>
         <LoadingState label="Loading skill..." />
+      </SectionLayout>
+    );
+  }
+  if (detailError) {
+    return (
+      <SectionLayout>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+          <AlertTriangle className="h-5 w-5 text-amber-400" />
+          <p className="text-sm font-medium text-foreground">Could not load {name}</p>
+          <p className="max-w-md text-xs text-muted-foreground">{detailError}</p>
+          <button
+            type="button"
+            onClick={onBack}
+            className="rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium hover:bg-muted"
+          >
+            Back to skills
+          </button>
+        </div>
       </SectionLayout>
     );
   }
@@ -925,7 +993,7 @@ function SkillDetailPanel({ name, onBack, onAction }: { name: string; onBack: ()
                 // Refresh skill detail
                 fetch("/api/skills?action=info&name=" + encodeURIComponent(name))
                   .then((r) => r.json())
-                  .then((d) => setDetail(d))
+                  .then((d) => { if (!readDetailError(d)) setDetail(d as SkillDetail); })
                   .catch(() => {});
               }
             }}

--- a/src/components/skills-view.tsx
+++ b/src/components/skills-view.tsx
@@ -31,6 +31,12 @@ type Skill = {
 
 type ClawHubItem = {
   slug: string;
+  /**
+   * Owner-qualified `@owner/slug`. Slugs are not unique across owners — a
+   * search for "weather" returns several — so this is what identifies a skill
+   * for install. Absent for catalog rows with no owner attached.
+   */
+  ref?: string;
   displayName?: string;
   summary?: string;
   version?: string;
@@ -1005,6 +1011,7 @@ function ClawHubPanel({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [clawhubNotFound, setClawhubNotFound] = useState(false);
+  const [browseNotice, setBrowseNotice] = useState<string | null>(null);
   const [copiedInstallCmd, setCopiedInstallCmd] = useState(false);
   const [busySlug, setBusySlug] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<"install" | "update" | "uninstall" | null>(null);
@@ -1089,12 +1096,16 @@ function ClawHubPanel({
         setLoading(false);
         return;
       }
+      // Browsing needs the standalone CLI, but search and install do not, so
+      // this is a note rather than the tab-wide "not found" state.
+      setBrowseNotice(typeof data?.notice === "string" ? data.notice : null);
       if (!res.ok || data?.error) {
         setClawhubNotFound(false);
         throw new Error(String(data?.error || `HTTP ${res.status}`));
       }
       const normalized: ClawHubItem[] = (data.items || []).map((item: {
         slug?: string;
+        ref?: string;
         displayName?: string;
         summary?: string;
         latestVersion?: { version?: string };
@@ -1104,6 +1115,7 @@ function ClawHubPanel({
         author?: string;
       }) => ({
         slug: String(item.slug || ""),
+        ref: item.ref || undefined,
         displayName: item.displayName || undefined,
         summary: item.summary || "",
         version: item.latestVersion?.version || "latest",
@@ -1128,6 +1140,7 @@ function ClawHubPanel({
     if (!q) return;
     setLoading(true);
     setMode("search");
+    setBrowseNotice(null);
     try {
       const res = await fetch(`/api/skills/clawhub?action=search&q=${encodeURIComponent(q)}&limit=28`);
       const data = await res.json();
@@ -1145,19 +1158,27 @@ function ClawHubPanel({
       }
       const normalized: ClawHubItem[] = (data.items || []).map((item: {
         slug?: string;
+        ref?: string;
         version?: string;
         summary?: string;
         score?: number;
         developer?: string;
         author?: string;
         displayName?: string;
+        stats?: { downloads?: number; installsCurrent?: number; stars?: number };
+        updatedAt?: number;
       }) => ({
         slug: String(item.slug || ""),
+        ref: item.ref || undefined,
         displayName: item.displayName || undefined,
         version: item.version || "latest",
         summary: item.summary || "",
         score: typeof item.score === "number" ? item.score : undefined,
         developer: (item.developer ?? item.author) || undefined,
+        downloads: item.stats?.downloads || 0,
+        installsCurrent: item.stats?.installsCurrent || 0,
+        stars: item.stats?.stars || 0,
+        updatedAt: item.updatedAt,
       })).filter((item: ClawHubItem) => item.slug);
       setItems(normalized);
       setError(null);
@@ -1169,14 +1190,14 @@ function ClawHubPanel({
     setLoading(false);
   }, [query]);
 
-  const installSkill = useCallback(async (slug: string, version?: string, force = false) => {
+  const installSkill = useCallback(async (slug: string, version?: string, force = false, ref?: string) => {
     setBusySlug(slug);
     setBusyAction("install");
     try {
       const res = await fetch("/api/skills/clawhub", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "install", slug, version, force }),
+        body: JSON.stringify({ action: "install", slug, ref, version, force }),
       });
       const data = await res.json();
       if (data?.code === "CLAWHUB_NOT_FOUND") {
@@ -1192,7 +1213,7 @@ function ClawHubPanel({
         if (isSuspicious && !force && window.confirm("This skill is flagged as suspicious by VirusTotal (e.g. risky patterns). Install anyway? Review the skill code after installing.")) {
           setBusySlug(null);
           setBusyAction(null);
-          return void installSkill(slug, version, true);
+          return void installSkill(slug, version, true, ref);
         }
         onAction(`Error: ${errMsg}`);
       } else {
@@ -1285,6 +1306,12 @@ function ClawHubPanel({
 
   return (
     <div className="space-y-3">
+      {browseNotice && !clawhubNotFound && (
+        <div className="flex items-start gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          <Search className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <p>{browseNotice}</p>
+        </div>
+      )}
       {clawhubNotFound && (
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-800 dark:text-amber-200">
           <div className="flex items-start gap-2">
@@ -1389,7 +1416,7 @@ function ClawHubPanel({
               const installLabel = isBusy && busyAction === "install" ? "Installing..." : isBusy && busyAction === "update" ? "Updating..." : isBusy && busyAction === "uninstall" ? "Deleting..." : isInstalled ? "Reinstall" : "Install";
               return (
                 <div
-                  key={item.slug}
+                  key={item.ref || item.slug}
                   className="glass w-full rounded-lg p-3.5 text-left transition-colors"
                 >
                   <div className="flex items-start justify-between gap-2">
@@ -1431,7 +1458,7 @@ function ClawHubPanel({
                           Delete
                         </button>
                       )}
-                      <button type="button" disabled={isBusy || clawhubNotFound} onClick={() => void installSkill(item.slug, item.version)} className="rounded-md border border-border bg-card px-2.5 py-0.5 text-xs font-medium text-foreground hover:bg-muted disabled:opacity-50">
+                      <button type="button" disabled={isBusy || clawhubNotFound} onClick={() => void installSkill(item.slug, item.version, false, item.ref)} className="rounded-md border border-border bg-card px-2.5 py-0.5 text-xs font-medium text-foreground hover:bg-muted disabled:opacity-50">
                         {installLabel}
                       </button>
                     </div>

--- a/src/lib/gateway-config.ts
+++ b/src/lib/gateway-config.ts
@@ -6,7 +6,7 @@
  * agents/route.ts and models-summary.ts.
  */
 
-import { gatewayCall, runCliCaptureBoth } from "./openclaw";
+import { CONFIG_WRITE_TIMEOUT_MS, gatewayCall, runCliCaptureBoth } from "./openclaw";
 import { getOpenClawHome } from "./paths";
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
@@ -150,7 +150,7 @@ async function applyConfigSetFallback(entries: ConfigSetEntry[]): Promise<{
       }
       const setResult = await runCliCaptureBoth(
         ["config", "set", "--strict-json", entry.path, encoded],
-        20000,
+        CONFIG_WRITE_TIMEOUT_MS,
       );
       if (setResult.code !== 0) {
         const details = String(setResult.stderr || setResult.stdout || "").trim();

--- a/src/lib/gateway-liveness.ts
+++ b/src/lib/gateway-liveness.ts
@@ -1,0 +1,42 @@
+/**
+ * Gateway liveness probe.
+ *
+ * OpenClaw documents `GET /health` as the endpoint for exactly this: it answers
+ * instantly, needs no auth, creates no session, and returns
+ * `{"ok":true,"status":"live"}`.
+ *
+ * Probing the gateway root instead reports a healthy gateway as offline or
+ * degraded whenever `/` is not a plain 200 — the Control UI can be disabled,
+ * served behind a reverse proxy, or gated by auth. `/health` is also cheap
+ * enough to poll, unlike `openclaw health --json`, which loads every plugin.
+ */
+
+const PROBE_TIMEOUT_MS = 3_000;
+
+/** True when the gateway answers its health endpoint as live. */
+export async function probeGatewayLiveness(
+  gatewayUrl: string,
+  timeoutMs = PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+  const base = gatewayUrl.replace(/\/+$/, "");
+  try {
+    const res = await fetch(`${base}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+      cache: "no-store",
+    });
+    if (res.ok) {
+      const body = (await res.json().catch(() => null)) as { ok?: unknown } | null;
+      // Treat a 200 without a parsable body as live: some proxies rewrite it.
+      return body?.ok !== false;
+    }
+    // A 404 means this build predates /health; fall back to the root probe so
+    // older gateways are not reported offline.
+    if (res.status === 404) {
+      const root = await fetch(base, { signal: AbortSignal.timeout(timeoutMs) });
+      return root.ok;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/gateway-protocol.ts
+++ b/src/lib/gateway-protocol.ts
@@ -1,0 +1,76 @@
+/**
+ * Gateway protocol constants for the OpenClaw WebSocket control plane.
+ *
+ * Mirrors `packages/gateway-protocol/src/version.ts` and
+ * `packages/gateway-protocol/src/client-info.ts` in OpenClaw. Keep these in
+ * sync when bumping the supported OpenClaw range — the gateway hard-rejects a
+ * handshake whose [minProtocol, maxProtocol] window excludes its own version.
+ */
+
+/** Protocol version spoken by current OpenClaw clients and servers. */
+export const GATEWAY_PROTOCOL_VERSION = 4;
+
+/**
+ * Lowest protocol an operator client may advertise. OpenClaw's
+ * `MIN_CLIENT_PROTOCOL_VERSION` is 4: the N-1 compatibility window only covers
+ * `role: "node"` clients and lightweight restart probes, so an operator client
+ * must advertise 4 exactly.
+ */
+export const GATEWAY_MIN_CLIENT_PROTOCOL_VERSION = 4;
+
+/**
+ * Client identity Mission Control presents at handshake.
+ *
+ * This pair is load-bearing, not cosmetic. The gateway only preserves the
+ * scopes requested by a client that has no paired device identity when it
+ * matches one of two exact combinations (`shouldSkipLocalBackendSelfPairing`
+ * and `shouldPreserveLocalCliSharedAuthScopes` in OpenClaw's gateway message
+ * handler):
+ *
+ *   - `gateway-client` + `backend` — a local backend service (this app)
+ *   - `cli` + `cli`               — the interactive CLI
+ *
+ * Any other pair connects successfully but is granted zero scopes, so every
+ * subsequent RPC fails with `missing scope: operator.read`.
+ */
+export const GATEWAY_CLIENT_ID = "gateway-client";
+export const GATEWAY_CLIENT_MODE = "backend";
+
+/** Operator scopes Mission Control needs to drive the whole dashboard. */
+export const GATEWAY_OPERATOR_SCOPES = [
+  "operator.read",
+  "operator.write",
+  "operator.admin",
+  "operator.approvals",
+  "operator.pairing",
+] as const;
+
+/**
+ * Connect-challenge budget. The gateway sends `connect.challenge` immediately
+ * after the socket opens; OpenClaw's reference client waits up to 15s for it.
+ */
+export const GATEWAY_CONNECT_CHALLENGE_TIMEOUT_MS = 15_000;
+
+/** Default per-request RPC timeout used by OpenClaw's reference client. */
+export const GATEWAY_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Version Mission Control reports at handshake. The gateway logs it against
+ * connection diagnostics, so report the real package version when readable.
+ */
+let _version: string | null = null;
+
+export function getMissionControlVersion(): string {
+  if (_version) return _version;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { join } = require("node:path") as typeof import("node:path");
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
+    _version = String(pkg.version || "").trim() || "0.0.0";
+  } catch {
+    _version = "0.0.0";
+  }
+  return _version;
+}

--- a/src/lib/gateway-rpc-channel.ts
+++ b/src/lib/gateway-rpc-channel.ts
@@ -1,0 +1,109 @@
+/**
+ * Gateway RPC channel — the control plane Mission Control actually runs on.
+ *
+ * The gateway's RPC surface is a WebSocket protocol, not an HTTP one. It used
+ * to be reached through the HTTP transport, which meant a failure of the
+ * unrelated `POST /tools/invoke` probe disabled config, sessions, cron, usage
+ * and skills across the whole dashboard. Current OpenClaw denies `exec` on
+ * that HTTP endpoint by default, so that probe now fails on every healthy
+ * install. RPC therefore owns its own connection and its own health here.
+ *
+ * Order of preference:
+ *   1. Direct WebSocket RPC (fast, no subprocess).
+ *   2. `openclaw gateway call <method>` (slower, but has the CLI's own auth and
+ *      works when the dashboard cannot authenticate as a local operator).
+ */
+
+import { GatewayRpcClient, GatewayRpcError } from "./gateway-rpc";
+
+/** Cooldown before retrying the WebSocket path after a transport failure. */
+const WS_RETRY_COOLDOWN_MS = 15_000;
+
+/**
+ * Whether a failure means "we never reached the gateway" (worth falling back to
+ * the CLI) rather than "the gateway answered with an error" (the CLI would
+ * return the same error, so don't pay for a subprocess).
+ */
+function isTransportFailure(err: unknown): boolean {
+  if (!(err instanceof GatewayRpcError)) return true;
+  // Errors the gateway itself produced carry its own machine-readable code.
+  // MISSING_SCOPES is ours, and specifically means the CLI may do better.
+  if (err.code && err.code !== "MISSING_SCOPES") return false;
+  return true;
+}
+
+export class GatewayRpcChannel {
+  private client: GatewayRpcClient | null = null;
+  private wsUnavailableUntil = 0;
+  private lastWsError: string | null = null;
+
+  constructor(
+    private readonly gatewayUrl?: string,
+    private readonly token?: string,
+  ) {}
+
+  /** Human-readable reason the WebSocket path is currently skipped, if any. */
+  getWsStatus(): { available: boolean; reason: string | null } {
+    if (Date.now() < this.wsUnavailableUntil) {
+      return { available: false, reason: this.lastWsError };
+    }
+    return { available: true, reason: null };
+  }
+
+  private getClient(): GatewayRpcClient {
+    if (!this.client) {
+      this.client = new GatewayRpcClient(this.gatewayUrl, this.token);
+    }
+    return this.client;
+  }
+
+  private markWsFailed(err: unknown): void {
+    this.lastWsError = err instanceof Error ? err.message : String(err);
+    this.wsUnavailableUntil = Date.now() + WS_RETRY_COOLDOWN_MS;
+    // Drop the client so the next attempt reconnects from scratch.
+    this.client = null;
+  }
+
+  /**
+   * Call a gateway RPC method, preferring the WebSocket control plane and
+   * falling back to the CLI when the socket path is unusable.
+   */
+  async request<T>(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeout = 15_000,
+  ): Promise<T> {
+    const wsUsable = Date.now() >= this.wsUnavailableUntil;
+
+    if (wsUsable) {
+      try {
+        return await this.getClient().request<T>(method, params, timeout);
+      } catch (err) {
+        if (!isTransportFailure(err)) throw err;
+        this.markWsFailed(err);
+        console.warn(
+          `[GatewayRpc] WebSocket RPC unavailable (${this.lastWsError}); falling back to \`openclaw gateway call\` for ${method}.`,
+        );
+      }
+    }
+
+    // CLI fallback. Imported lazily so the CLI module is only loaded when a
+    // subprocess is actually needed.
+    const { gatewayCall } = await import("./openclaw-cli");
+    return gatewayCall<T>(method, params, timeout);
+  }
+}
+
+// ── Process-wide singleton ────────────────────────
+
+let _channel: GatewayRpcChannel | null = null;
+
+export function getGatewayRpcChannel(): GatewayRpcChannel {
+  if (!_channel) _channel = new GatewayRpcChannel();
+  return _channel;
+}
+
+/** Reset the singleton (for testing). */
+export function resetGatewayRpcChannel(): void {
+  _channel = null;
+}

--- a/src/lib/gateway-rpc.ts
+++ b/src/lib/gateway-rpc.ts
@@ -1,11 +1,30 @@
 import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { getGatewayToken, getGatewayUrl, getOpenClawHome } from "./paths";
+import {
+  GATEWAY_CLIENT_ID,
+  GATEWAY_CLIENT_MODE,
+  GATEWAY_CONNECT_CHALLENGE_TIMEOUT_MS,
+  GATEWAY_MIN_CLIENT_PROTOCOL_VERSION,
+  GATEWAY_OPERATOR_SCOPES,
+  GATEWAY_PROTOCOL_VERSION,
+  getMissionControlVersion,
+} from "./gateway-protocol";
+import {
+  getGatewayPassword,
+  getGatewayToken,
+  getGatewayUrl,
+  getOpenClawHome,
+} from "./paths";
 
 type GatewayConnectHello = {
+  protocol?: number;
   features?: {
     methods?: string[];
+  };
+  auth?: {
+    role?: string;
+    scopes?: string[];
   };
 };
 
@@ -170,6 +189,26 @@ export class GatewayRpcError extends Error {
   }
 }
 
+/**
+ * Raised when the handshake succeeds but the gateway grants no operator
+ * scopes. Every RPC would fail with `missing scope: ...`, so surface the
+ * actionable cause instead of letting each call fail separately.
+ */
+export class GatewayScopeError extends GatewayRpcError {
+  constructor(granted: string[]) {
+    super(
+      "Gateway granted no operator scopes to Mission Control. " +
+        "Configure gateway auth (gateway.auth.token / OPENCLAW_GATEWAY_TOKEN, or " +
+        "gateway.auth.password) so this host authenticates as a local operator, " +
+        "or approve its device identity with `openclaw devices approve`. " +
+        `Granted scopes: [${granted.join(", ")}]`,
+      "MISSING_SCOPES",
+      { granted },
+    );
+    this.name = "GatewayScopeError";
+  }
+}
+
 export class GatewayRpcClient {
   private ws: WebSocket | null = null;
   private connectPromise: Promise<void> | null = null;
@@ -180,10 +219,18 @@ export class GatewayRpcClient {
   private connectTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   private connectKickTimer: ReturnType<typeof setTimeout> | null = null;
   private connectNonce: string | null = null;
-  private supportedMethods = new Set<string>();
+  /**
+   * Methods advertised in `hello-ok.features.methods`. Advisory only: OpenClaw
+   * builds this list conservatively and intentionally omits real, callable
+   * methods (`sessions.usage`, `plugins.list`, `audit.activity.list`, …), so it
+   * must never be used to reject a request.
+   */
+  private advertisedMethods = new Set<string>();
+  private grantedScopes: string[] = [];
   private pending = new Map<string, PendingRequest>();
   private seq = 0;
   private readonly token: string;
+  private readonly password: string;
   private readonly gatewayUrl?: string;
   private listeners: {
     open?: () => void;
@@ -192,9 +239,20 @@ export class GatewayRpcClient {
     error?: () => void;
   } = {};
 
-  constructor(gatewayUrl?: string, token?: string) {
+  constructor(gatewayUrl?: string, token?: string, password?: string) {
     this.gatewayUrl = gatewayUrl;
     this.token = token ?? getGatewayToken();
+    this.password = password ?? getGatewayPassword();
+  }
+
+  /** Operator scopes the gateway granted on the current connection. */
+  getGrantedScopes(): string[] {
+    return [...this.grantedScopes];
+  }
+
+  /** Whether the gateway advertised this method in `hello-ok` (advisory). */
+  advertisesMethod(method: string): boolean {
+    return this.advertisedMethods.has(method);
   }
 
   async request<T>(
@@ -203,10 +261,6 @@ export class GatewayRpcClient {
     timeout = 15000,
   ): Promise<T> {
     await this.connect(timeout);
-
-    if (this.supportedMethods.size > 0 && !this.supportedMethods.has(method)) {
-      throw new GatewayRpcError(`Gateway does not support method: ${method}`, "UNSUPPORTED_METHOD");
-    }
 
     const ws = this.ws;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -337,7 +391,15 @@ export class GatewayRpcClient {
     if (message.id && message.id === this.connectRequestId) {
       if (message.ok) {
         const hello = (message.payload || {}) as GatewayConnectHello;
-        this.supportedMethods = new Set(hello.features?.methods || []);
+        this.advertisedMethods = new Set(hello.features?.methods || []);
+        this.grantedScopes = Array.isArray(hello.auth?.scopes) ? hello.auth!.scopes! : [];
+        // A handshake can succeed with zero scopes (unpaired device, or a
+        // client identity the gateway does not treat as a local operator).
+        // Every later RPC would fail; fail the connect instead.
+        if (this.grantedScopes.length === 0) {
+          this.connectReject?.(new GatewayScopeError(this.grantedScopes));
+          return;
+        }
         this.connectResolve?.();
       } else {
         this.connectReject?.(this.normalizeGatewayError(message.error));
@@ -361,6 +423,12 @@ export class GatewayRpcClient {
     pending.reject(this.normalizeGatewayError(message.error));
   }
 
+  /**
+   * The gateway emits `connect.challenge` right after the socket opens and its
+   * nonce is required to sign a device identity. Wait for it rather than racing
+   * ahead, but still send an unsigned connect if it never arrives so shared-
+   * secret auth keeps working.
+   */
   private scheduleConnectRequest(): void {
     if (this.connectRequestSent || this.connectKickTimer) {
       return;
@@ -368,7 +436,7 @@ export class GatewayRpcClient {
     const timer = setTimeout(() => {
       this.connectKickTimer = null;
       this.sendConnectRequest();
-    }, 750);
+    }, GATEWAY_CONNECT_CHALLENGE_TIMEOUT_MS);
     this.connectKickTimer = timer;
   }
 
@@ -387,13 +455,7 @@ export class GatewayRpcClient {
       this.connectKickTimer = null;
     }
 
-    const scopes = [
-      "operator.read",
-      "operator.write",
-      "operator.admin",
-      "operator.approvals",
-      "operator.pairing",
-    ];
+    const scopes = [...GATEWAY_OPERATOR_SCOPES];
     const nonce = this.connectNonce || "";
 
     // Resolve device identity and auth tokens for signed connect.
@@ -401,24 +463,28 @@ export class GatewayRpcClient {
     const authTokens = loadDeviceAuthTokens();
     const deviceToken = authTokens?.operator?.token;
 
-    // Build auth: prefer device token over gateway token.
+    // Build auth. Shared-secret auth (token or password, depending on
+    // gateway.auth.mode) is what makes a loopback backend client a trusted
+    // local operator; a paired device token also works.
     const authToken = this.token || undefined;
+    const authPassword = this.password || undefined;
     const auth: Record<string, unknown> = {};
     if (authToken) auth.token = authToken;
+    if (authPassword) auth.password = authPassword;
     if (deviceToken) auth.deviceToken = deviceToken;
 
     // Build device signature if identity is available and we have a nonce.
     let device: Record<string, unknown> | undefined;
     if (identity && nonce) {
       const signedAtMs = Date.now();
-      // Token used for signature: must match what auth.token sends.
-      // The gateway verifies the signature against the token in the connect
-      // request. When a gateway token is present it takes precedence.
+      // The gateway recomputes this payload from the connect frame, so every
+      // signed field must match exactly what we send below — including the
+      // client id and mode.
       const signatureToken = authToken || deviceToken || null;
       const payload = buildDeviceAuthPayloadV3({
         deviceId: identity.deviceId,
-        clientId: "cli",
-        clientMode: "backend",
+        clientId: GATEWAY_CLIENT_ID,
+        clientMode: GATEWAY_CLIENT_MODE,
         role: "operator",
         scopes,
         signedAtMs,
@@ -442,13 +508,14 @@ export class GatewayRpcClient {
         id: this.connectRequestId,
         method: "connect",
         params: {
-          minProtocol: 3,
-          maxProtocol: 3,
+          minProtocol: GATEWAY_MIN_CLIENT_PROTOCOL_VERSION,
+          maxProtocol: GATEWAY_PROTOCOL_VERSION,
           client: {
-            id: "cli",
-            version: "mission-control",
+            id: GATEWAY_CLIENT_ID,
+            displayName: "Mission Control",
+            version: getMissionControlVersion(),
             platform: process.platform,
-            mode: "backend",
+            mode: GATEWAY_CLIENT_MODE,
             instanceId: `pid-${process.pid}`,
           },
           role: "operator",
@@ -457,7 +524,7 @@ export class GatewayRpcClient {
           ...(Object.keys(auth).length > 0 ? { auth } : {}),
           ...(device ? { device } : {}),
           locale: "en-US",
-          userAgent: "@openclaw/dashboard",
+          userAgent: `@openclaw/dashboard/${getMissionControlVersion()}`,
         },
       }),
     );
@@ -472,7 +539,8 @@ export class GatewayRpcClient {
       pending.reject(error);
       this.pending.delete(id);
     }
-    this.supportedMethods.clear();
+    this.advertisedMethods.clear();
+    this.grantedScopes = [];
     this.closeSocket();
   }
 

--- a/src/lib/openclaw.ts
+++ b/src/lib/openclaw.ts
@@ -15,6 +15,18 @@ import type { RunCliResult } from "./openclaw-cli";
 export type { RunCliResult } from "./openclaw-cli";
 export { parseJsonFromCliOutput } from "./openclaw-cli";
 
+/**
+ * Budget for a CLI *write* to the config.
+ *
+ * `openclaw config set` is not a cheap file edit: the subprocess initialises the
+ * full plugin loader and runs doctor checks first, so on a cold cache — a large
+ * plugin set, slow disk, or the first call after an update rebuilds it — it can
+ * take far longer than a read. The default 15s produced the worst possible
+ * outcome, aborting mid-write and reporting "This operation was aborted" for a
+ * change that may already have landed (#82). Prefer waiting to that ambiguity.
+ */
+export const CONFIG_WRITE_TIMEOUT_MS = 60_000;
+
 export async function runCli(
   args: string[],
   timeout = 15000,

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -70,34 +70,63 @@ export async function readConfigFile(): Promise<Record<string, unknown>> {
 
 let _workspace: string | null = null;
 
+let _defaultAgent: { id: string; workspace: string | null } | null = null;
+
 /**
- * Ask the gateway where the default agent's workspace is.
+ * Ask the gateway which agent is the default, and where its workspace is.
  *
- * This is the only source that is actually authoritative. OpenClaw gives each
- * agent its own directory named after the agent id — a stock install's default
- * agent `dev` lives in `$OPENCLAW_HOME/workspace-dev`, not
+ * This is the only authoritative source for either. OpenClaw gives each agent
+ * its own directory named after the agent id — a stock install's default agent
+ * `dev` lives in `$OPENCLAW_HOME/workspace-dev`, not
  * `$OPENCLAW_HOME/workspace` — and the id is not derivable from the path.
+ *
+ * There is no safe default for the id either. `agents.list` reports `mainKey:
+ * "main"` alongside a sole agent whose id is `dev`, and the two behave
+ * differently: the RPC rejects `agentId: "main"` as unknown, while the CLI
+ * accepts `--agent main` and silently resolves it to a workspace *inside* the
+ * real one (`workspace-dev/main`). So assuming "main" does not fail loudly, it
+ * targets the wrong place.
  *
  * Imported lazily because `openclaw.ts` pulls in the transports, which import
  * this module; a top-level import would be a cycle.
  */
-async function workspaceFromGateway(): Promise<string | null> {
+export async function getDefaultAgent(): Promise<{
+  id: string;
+  workspace: string | null;
+} | null> {
+  if (_defaultAgent) return _defaultAgent;
   try {
     const { gatewayCall } = await import("./openclaw");
     const payload = await gatewayCall<{
       defaultId?: string;
-      agents?: { id?: string; workspace?: string }[];
+      agents?: { id?: string; workspace?: string; isDefault?: boolean }[];
     }>("agents.list", {}, 8000);
 
     const agents = Array.isArray(payload?.agents) ? payload.agents : [];
     const preferred =
       agents.find((agent) => agent?.id && agent.id === payload?.defaultId) ??
+      agents.find((agent) => agent?.isDefault) ??
       agents[0];
-    const workspace = preferred?.workspace;
-    return typeof workspace === "string" && workspace.trim() ? workspace : null;
+    if (!preferred?.id) return null;
+
+    const workspace =
+      typeof preferred.workspace === "string" && preferred.workspace.trim()
+        ? preferred.workspace
+        : null;
+    _defaultAgent = { id: preferred.id, workspace };
+    return _defaultAgent;
   } catch {
     return null;
   }
+}
+
+/**
+ * Id of the default agent, or null when the gateway cannot be reached. Callers
+ * should omit the agent argument rather than substituting a guess — OpenClaw
+ * resolves the default itself, and a wrong id is worse than none.
+ */
+export async function getDefaultAgentId(): Promise<string | null> {
+  return (await getDefaultAgent())?.id ?? null;
 }
 
 /**
@@ -118,7 +147,7 @@ export async function getDefaultWorkspace(): Promise<string> {
   }
 
   // 2. The running gateway
-  const fromGateway = await workspaceFromGateway();
+  const fromGateway = (await getDefaultAgent())?.workspace;
   if (fromGateway) {
     _workspace = fromGateway;
     return _workspace;

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -354,6 +354,23 @@ let _gatewayToken: string | null = null;
  *
  * Priority: env var → openclaw.json gateway.auth.token → empty string.
  */
+/** Read a dot path out of openclaw.json synchronously, tolerating any failure. */
+function readConfigValueSync(path: string[]): unknown {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { readFileSync } = require("fs") as typeof import("fs");
+    const raw = readFileSync(join(getOpenClawHome(), "openclaw.json"), "utf-8");
+    let node: unknown = JSON.parse(raw);
+    for (const key of path) {
+      if (!node || typeof node !== "object") return undefined;
+      node = (node as Record<string, unknown>)[key];
+    }
+    return node;
+  } catch {
+    return undefined;
+  }
+}
+
 export function getGatewayToken(): string {
   if (_gatewayToken !== null) return _gatewayToken;
 
@@ -363,21 +380,41 @@ export function getGatewayToken(): string {
     return _gatewayToken;
   }
 
-  // 2. Read from config (sync — token is needed synchronously by callers)
-  try {
-    const { readFileSync } = require("fs");
-    const configPath = join(getOpenClawHome(), "openclaw.json");
-    const raw = readFileSync(configPath, "utf-8");
-    const config = JSON.parse(raw);
-    const token = config?.gateway?.auth?.token;
-    if (token && typeof token === "string") {
-      _gatewayToken = token;
-      return _gatewayToken;
-    }
-  } catch {
-    // Config doesn't exist or is invalid — fall through
+  // 2. Read from config (sync — token is needed synchronously by callers).
+  // `gateway.token` is a legacy key the gateway no longer honors, so only
+  // `gateway.auth.token` is read here.
+  const token = readConfigValueSync(["gateway", "auth", "token"]);
+  _gatewayToken = typeof token === "string" && token ? token : "";
+  return _gatewayToken;
+}
+
+// ── Gateway auth password ───────────────────────
+
+let _gatewayPassword: string | null = null;
+
+/**
+ * Resolve the Gateway password used when `gateway.auth.mode` is `"password"`.
+ *
+ * Shared-secret auth is what lets a loopback backend client authenticate as a
+ * local operator, and installs that chose password mode have no token at all.
+ *
+ * Priority: env var → openclaw.json gateway.auth.password → empty string.
+ */
+export function getGatewayPassword(): string {
+  if (_gatewayPassword !== null) return _gatewayPassword;
+
+  if (process.env.OPENCLAW_GATEWAY_PASSWORD) {
+    _gatewayPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    return _gatewayPassword;
   }
 
-  _gatewayToken = "";
-  return _gatewayToken;
+  const password = readConfigValueSync(["gateway", "auth", "password"]);
+  _gatewayPassword = typeof password === "string" && password ? password : "";
+  return _gatewayPassword;
+}
+
+/** Resolve `gateway.auth.mode` ("none" | "token" | "password" | "trusted-proxy"). */
+export function getGatewayAuthMode(): string {
+  const mode = readConfigValueSync(["gateway", "auth", "mode"]);
+  return typeof mode === "string" && mode ? mode : "none";
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -71,11 +71,42 @@ export async function readConfigFile(): Promise<Record<string, unknown>> {
 let _workspace: string | null = null;
 
 /**
+ * Ask the gateway where the default agent's workspace is.
+ *
+ * This is the only source that is actually authoritative. OpenClaw gives each
+ * agent its own directory named after the agent id — a stock install's default
+ * agent `dev` lives in `$OPENCLAW_HOME/workspace-dev`, not
+ * `$OPENCLAW_HOME/workspace` — and the id is not derivable from the path.
+ *
+ * Imported lazily because `openclaw.ts` pulls in the transports, which import
+ * this module; a top-level import would be a cycle.
+ */
+async function workspaceFromGateway(): Promise<string | null> {
+  try {
+    const { gatewayCall } = await import("./openclaw");
+    const payload = await gatewayCall<{
+      defaultId?: string;
+      agents?: { id?: string; workspace?: string }[];
+    }>("agents.list", {}, 8000);
+
+    const agents = Array.isArray(payload?.agents) ? payload.agents : [];
+    const preferred =
+      agents.find((agent) => agent?.id && agent.id === payload?.defaultId) ??
+      agents[0];
+    const workspace = preferred?.workspace;
+    return typeof workspace === "string" && workspace.trim() ? workspace : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Resolve the default agent workspace path.
  * Priority:
  *   1. OPENCLAW_WORKSPACE env var
- *   2. agents.defaults.workspace from openclaw.json
- *   3. $OPENCLAW_HOME/workspace
+ *   2. The default agent's workspace, per the gateway
+ *   3. agents.defaults.workspace from openclaw.json
+ *   4. $OPENCLAW_HOME/workspace
  */
 export async function getDefaultWorkspace(): Promise<string> {
   if (_workspace) return _workspace;
@@ -86,7 +117,14 @@ export async function getDefaultWorkspace(): Promise<string> {
     return _workspace;
   }
 
-  // 2. Read from config
+  // 2. The running gateway
+  const fromGateway = await workspaceFromGateway();
+  if (fromGateway) {
+    _workspace = fromGateway;
+    return _workspace;
+  }
+
+  // 3. Read from config
   try {
     const { readFile } = await import("fs/promises");
     const configPath = join(getOpenClawHome(), "openclaw.json");
@@ -101,9 +139,9 @@ export async function getDefaultWorkspace(): Promise<string> {
     // Config doesn't exist or is invalid — fall through
   }
 
-  // 3. Conventional default
-  _workspace = join(getOpenClawHome(), "workspace");
-  return _workspace;
+  // 4. Conventional default. Note this misses the per-agent suffix, so it is a
+  // guess of last resort rather than the expected outcome.
+  return join(getOpenClawHome(), "workspace");
 }
 
 /** Synchronous accessor — uses cached value or falls back to convention. */

--- a/src/lib/responses-endpoint.ts
+++ b/src/lib/responses-endpoint.ts
@@ -1,0 +1,83 @@
+/**
+ * Auto-enable the gateway's OpenResponses endpoint, which streaming chat needs.
+ *
+ * `gateway.http.endpoints.responses.enabled` is off by default, and enabling it
+ * requires a config patch plus a gateway restart. This kicks that off in the
+ * background from the health poll so a user who opens chat does not have to
+ * discover the setting, and lets the chat routes wait on the in-flight attempt
+ * rather than racing it.
+ *
+ * Attempts are rate-limited by a cooldown and never retried in a tight loop:
+ * each one restarts the gateway, so a failing patch would otherwise become a
+ * restart loop (#20).
+ *
+ * This lives in `lib` rather than beside the health route because Next.js 16
+ * rejects a route module that exports anything other than route handlers and
+ * its known config fields — importing these from `api/gateway/route.ts` failed
+ * the production build with "'waitForResponsesEndpoint' is not a valid Route
+ * export field".
+ */
+
+import { gatewayCall } from "./openclaw";
+import { gatewayConfigPatch } from "./gateway-config";
+
+let _ensured = false;
+let _lastAttempt = 0;
+const RETRY_COOLDOWN_MS = 5 * 60_000;
+
+/** Resolves when the current setup attempt completes, successfully or not. */
+let _setupPromise: Promise<void> | null = null;
+
+/** Start the setup attempt unless one already succeeded or ran recently. */
+export function triggerResponsesEndpointSetup(): void {
+  if (_ensured) return;
+  if (Date.now() - _lastAttempt < RETRY_COOLDOWN_MS) return;
+  _lastAttempt = Date.now();
+
+  // Fire-and-forget: the health check must not block on this.
+  _setupPromise = (async () => {
+    try {
+      const cfg = await gatewayCall<{
+        hash?: string;
+        parsed?: Record<string, unknown>;
+        config?: Record<string, unknown>;
+      }>("config.get", undefined, 8000);
+
+      // `parsed` is the current shape; `config` covers older gateways.
+      const root = cfg?.parsed ?? cfg?.config ?? {};
+      const gw = (root as Record<string, unknown>)?.gateway as Record<string, unknown> | undefined;
+      const http = gw?.http as Record<string, unknown> | undefined;
+      const endpoints = http?.endpoints as Record<string, unknown> | undefined;
+      const responses = endpoints?.responses as Record<string, unknown> | undefined;
+      if (responses?.enabled === true) {
+        _ensured = true;
+        return;
+      }
+
+      await gatewayConfigPatch(
+        {
+          raw: JSON.stringify({
+            gateway: { http: { endpoints: { responses: { enabled: true } } } },
+          }),
+          baseHash: String(cfg?.hash || ""),
+          restartDelayMs: 3000,
+        },
+        10000,
+      );
+      _ensured = true;
+    } catch {
+      // Non-fatal: streaming falls back to non-streaming. Deliberately does not
+      // clear `_ensured` — the cooldown is what schedules the next attempt.
+    } finally {
+      _setupPromise = null;
+    }
+  })();
+}
+
+/**
+ * Wait for an in-flight setup attempt, so a message sent before the health poll
+ * has finished does not race the restart.
+ */
+export async function waitForResponsesEndpoint(): Promise<void> {
+  if (_setupPromise) await _setupPromise;
+}

--- a/src/lib/skills-status.ts
+++ b/src/lib/skills-status.ts
@@ -14,6 +14,7 @@
  */
 
 import { gatewayCall, runCliJson } from "./openclaw";
+import { GatewayRpcError } from "./gateway-rpc";
 
 export type SkillRequirements = {
   bins: string[];
@@ -134,6 +135,19 @@ export async function fetchSkillsStatusViaCli(
 }
 
 /**
+ * Whether the CLI is worth trying after an RPC failure.
+ *
+ * Only when we failed to *reach* the gateway. If the gateway rejected the
+ * request itself, the CLI is not a second opinion — and for an unknown agent id
+ * it is actively worse: the RPC answers `unknown agent id "main"`, while
+ * `skills list --agent main` accepts it and reports a workspace nested inside
+ * the real one. Retrying there converts a clear error into wrong data.
+ */
+function shouldTryCli(err: unknown): boolean {
+  return !(err instanceof GatewayRpcError && err.code === "INVALID_REQUEST");
+}
+
+/**
  * Inventory from whichever source answers, preferring the RPC. Reports which
  * one won so callers can tell a full snapshot from a list-only one.
  */
@@ -143,6 +157,7 @@ export async function loadSkillsInventory(
   try {
     return { status: await fetchSkillsStatus(agentId), source: "rpc" };
   } catch (rpcErr) {
+    if (!shouldTryCli(rpcErr)) throw rpcErr;
     const status = await fetchSkillsStatusViaCli(agentId);
     return {
       status,

--- a/src/lib/skills-status.ts
+++ b/src/lib/skills-status.ts
@@ -1,0 +1,278 @@
+/**
+ * Local skill inventory via the Gateway `skills.status` RPC.
+ *
+ * `skills.status` (scope `operator.read`) returns one row per installed skill,
+ * and each row carries the same fields as `openclaw skills info <name> --json`
+ * — a superset of `skills list`. So a single call answers the list view, the
+ * check view and every detail view, where the CLI needs one subprocess per
+ * view (~2.5s each) and one more per skill opened.
+ *
+ * Note `skills.detail` and `skills.search` are *not* the detail/list methods
+ * for installed skills: both query the remote ClawHub registry and return
+ * publishing metadata (owner, downloads, moderation verdict). They are keyed by
+ * `slug`, not `name`. `/api/skills/clawhub` is the route that wants those.
+ */
+
+import { gatewayCall, runCliJson } from "./openclaw";
+
+export type SkillRequirements = {
+  bins: string[];
+  anyBins: string[];
+  env: string[];
+  config: string[];
+  os: string[];
+};
+
+export type SkillStatusRow = {
+  name: string;
+  description: string;
+  source: string;
+  bundled: boolean;
+  filePath?: string;
+  baseDir?: string;
+  skillKey?: string;
+  emoji?: string;
+  homepage?: string;
+  always?: boolean;
+  disabled: boolean;
+  blockedByAllowlist: boolean;
+  blockedByAgentFilter?: boolean;
+  eligible: boolean;
+  platformIncompatible?: boolean;
+  modelVisible?: boolean;
+  userInvocable?: boolean;
+  commandVisible?: boolean;
+  primaryEnv?: string;
+  requirements?: SkillRequirements;
+  missing?: SkillRequirements;
+  configChecks?: unknown[];
+  install?: { id: string; kind: string; label: string; bins?: string[] }[];
+};
+
+export type SkillsStatus = {
+  workspaceDir: string;
+  managedSkillsDir: string;
+  agentId?: string;
+  skills: SkillStatusRow[];
+};
+
+const EMPTY_REQUIREMENTS: SkillRequirements = {
+  bins: [],
+  anyBins: [],
+  env: [],
+  config: [],
+  os: [],
+};
+
+function normalizeRequirements(value: unknown): SkillRequirements {
+  if (!value || typeof value !== "object") return { ...EMPTY_REQUIREMENTS };
+  const record = value as Record<string, unknown>;
+  const list = (key: keyof SkillRequirements): string[] =>
+    Array.isArray(record[key]) ? (record[key] as unknown[]).map(String) : [];
+  return {
+    bins: list("bins"),
+    anyBins: list("anyBins"),
+    env: list("env"),
+    config: list("config"),
+    os: list("os"),
+  };
+}
+
+function normalizeStatus(payload: Partial<SkillsStatus> | null): SkillsStatus {
+  const skills = Array.isArray(payload?.skills) ? payload.skills : [];
+  return {
+    workspaceDir: String(payload?.workspaceDir || ""),
+    managedSkillsDir: String(payload?.managedSkillsDir || ""),
+    agentId: payload?.agentId,
+    skills: skills
+      .filter((row) => row && typeof row === "object")
+      .map((row) => ({
+        ...row,
+        name: String(row?.name || ""),
+        description: String(row?.description || ""),
+        source: String(row?.source || "workspace"),
+        bundled: Boolean(row?.bundled),
+        disabled: Boolean(row?.disabled),
+        blockedByAllowlist: Boolean(row?.blockedByAllowlist),
+        eligible: Boolean(row?.eligible),
+        requirements: normalizeRequirements(row?.requirements),
+        missing: normalizeRequirements(row?.missing),
+      })),
+  };
+}
+
+/**
+ * Fetch the skill inventory for one agent (the default agent when omitted).
+ *
+ * `agentId` must be a real id from `agents.list` — the gateway rejects an
+ * unknown one outright rather than falling back to the default.
+ */
+export async function fetchSkillsStatus(
+  agentId?: string,
+  timeout = 15_000,
+): Promise<SkillsStatus> {
+  const payload = await gatewayCall<Partial<SkillsStatus>>(
+    "skills.status",
+    agentId ? { agentId } : {},
+    timeout,
+  );
+  return normalizeStatus(payload);
+}
+
+/**
+ * Same inventory via `openclaw skills list --json`. Rows lack the detail-only
+ * fields (`filePath`, `requirements`, `install`, …), so this is a fallback for
+ * the list and check views rather than an equivalent source.
+ */
+export async function fetchSkillsStatusViaCli(
+  agentId?: string,
+  timeout = 20_000,
+): Promise<SkillsStatus> {
+  const args = ["skills", "list"];
+  if (agentId) args.push("--agent", agentId);
+  return normalizeStatus(await runCliJson<Partial<SkillsStatus>>(args, timeout));
+}
+
+/**
+ * Inventory from whichever source answers, preferring the RPC. Reports which
+ * one won so callers can tell a full snapshot from a list-only one.
+ */
+export async function loadSkillsInventory(
+  agentId?: string,
+): Promise<{ status: SkillsStatus; source: "rpc" | "cli"; warning?: string }> {
+  try {
+    return { status: await fetchSkillsStatus(agentId), source: "rpc" };
+  } catch (rpcErr) {
+    const status = await fetchSkillsStatusViaCli(agentId);
+    return {
+      status,
+      source: "cli",
+      warning: `skills.status RPC unavailable (${rpcErr instanceof Error ? rpcErr.message : String(rpcErr)}); used the CLI instead.`,
+    };
+  }
+}
+
+function hasMissing(missing: SkillRequirements): boolean {
+  return (
+    missing.bins.length > 0 ||
+    missing.anyBins.length > 0 ||
+    missing.env.length > 0 ||
+    missing.config.length > 0 ||
+    missing.os.length > 0
+  );
+}
+
+/**
+ * Shape of `openclaw skills check --json` as of OpenClaw 2026.7.
+ *
+ * `missingRequirements[].missing` is a requirements object, not the flat string
+ * list older versions returned, and `agentFiltered` / `notInjected` /
+ * `modelVisible` / `commandVisible` are newer buckets.
+ */
+export type SkillsCheckPayload = {
+  agentId?: string;
+  workspaceDir: string;
+  managedSkillsDir: string;
+  summary: {
+    total: number;
+    eligible: number;
+    modelVisible: number;
+    commandVisible: number;
+    disabled: number;
+    blocked: number;
+    agentFiltered: number;
+    notInjected: number;
+    missingRequirements: number;
+  };
+  eligible: string[];
+  modelVisible: string[];
+  commandVisible: string[];
+  disabled: string[];
+  blocked: string[];
+  agentFiltered: string[];
+  notInjected: string[];
+  missingRequirements: {
+    name: string;
+    missing: SkillRequirements;
+    install: SkillStatusRow["install"];
+  }[];
+};
+
+/**
+ * Derive the check view from a status snapshot instead of asking for it.
+ *
+ * The CLI computes these buckets from the same per-skill fields the snapshot
+ * already carries, so this saves a second call. The buckets are independent,
+ * matching the CLI: a disabled skill with a missing binary appears in both
+ * `disabled` and `missingRequirements`.
+ */
+export function deriveSkillsCheck(status: SkillsStatus): SkillsCheckPayload {
+  const eligible: string[] = [];
+  const modelVisible: string[] = [];
+  const commandVisible: string[] = [];
+  const disabled: string[] = [];
+  const blocked: string[] = [];
+  const agentFiltered: string[] = [];
+  const notInjected: string[] = [];
+  const missingRequirements: SkillsCheckPayload["missingRequirements"] = [];
+
+  for (const skill of status.skills) {
+    if (skill.eligible) eligible.push(skill.name);
+    if (skill.modelVisible) modelVisible.push(skill.name);
+    if (skill.commandVisible) commandVisible.push(skill.name);
+    if (skill.disabled) disabled.push(skill.name);
+    if (skill.blockedByAllowlist) blocked.push(skill.name);
+    if (skill.blockedByAgentFilter) agentFiltered.push(skill.name);
+    if (skill.eligible && !skill.modelVisible && !skill.commandVisible) {
+      notInjected.push(skill.name);
+    }
+    const missing = skill.missing ?? EMPTY_REQUIREMENTS;
+    if (hasMissing(missing)) {
+      missingRequirements.push({
+        name: skill.name,
+        missing,
+        install: skill.install ?? [],
+      });
+    }
+  }
+
+  return {
+    agentId: status.agentId,
+    workspaceDir: status.workspaceDir,
+    managedSkillsDir: status.managedSkillsDir,
+    summary: {
+      total: status.skills.length,
+      eligible: eligible.length,
+      modelVisible: modelVisible.length,
+      commandVisible: commandVisible.length,
+      disabled: disabled.length,
+      blocked: blocked.length,
+      agentFiltered: agentFiltered.length,
+      notInjected: notInjected.length,
+      missingRequirements: missingRequirements.length,
+    },
+    eligible,
+    modelVisible,
+    commandVisible,
+    disabled,
+    blocked,
+    agentFiltered,
+    notInjected,
+    missingRequirements,
+  };
+}
+
+/** Find one skill row by name or skill key. */
+export function findSkillRow(
+  status: SkillsStatus,
+  name: string,
+): SkillStatusRow | null {
+  const needle = name.trim().toLowerCase();
+  return (
+    status.skills.find(
+      (skill) =>
+        skill.name.toLowerCase() === needle ||
+        String(skill.skillKey || "").toLowerCase() === needle,
+    ) ?? null
+  );
+}

--- a/src/lib/transports/auto-transport.ts
+++ b/src/lib/transports/auto-transport.ts
@@ -1,17 +1,22 @@
 /**
- * Auto transport — tries HTTP first, falls back to CLI.
+ * Auto transport — picks the best way to reach OpenClaw for each kind of call.
  *
- * Probes /tools/invoke (not just "/") so non-200 root responses don't
- * incorrectly demote transport to CLI on VPS/reverse-proxy setups.
+ * There are two independent channels, and conflating them was the cause of the
+ * "gateway is not reachable via HTTP" failures across the dashboard:
  *
- * Circuit breaker: when the gateway returns scope/auth errors (403, 401,
- * "missing scope", "forbidden"), HTTP is permanently disabled for the
- * lifetime of this process. These errors indicate a fundamental
- * configuration mismatch that won't resolve on its own.
+ *   - Gateway RPC (WebSocket) drives config, sessions, cron, agents, models,
+ *     channels, skills, usage and health. It is handled by GatewayRpcChannel,
+ *     which has its own health and its own CLI fallback.
+ *
+ *   - Running `openclaw <cmd>` needs either a local subprocess or the gateway's
+ *     `exec` tool over `POST /tools/invoke`. Current OpenClaw denies `exec`
+ *     there by default (DEFAULT_GATEWAY_HTTP_TOOL_DENY), so the subprocess is
+ *     the default and HTTP is used only where a probe proves `exec` is exposed.
  */
 
 import type { OpenClawClient, TransportMode } from "../openclaw-client";
 import type { RunCliResult } from "../openclaw-cli";
+import { getGatewayRpcChannel } from "../gateway-rpc-channel";
 import { CliTransport } from "./cli-transport";
 import { HttpTransport } from "./http-transport";
 
@@ -20,7 +25,10 @@ function errorToMessage(err: unknown): string {
   return String(err);
 }
 
-/** Patterns that indicate a permanent scope/auth mismatch — no point retrying HTTP. */
+/** How long a verdict about the HTTP `exec` bridge stays valid. */
+const EXEC_BRIDGE_TTL_MS = 5 * 60_000;
+
+/** Patterns showing the gateway refused us outright rather than transiently. */
 const PERMANENT_FAILURE_PATTERNS = [
   "missing scope",
   "forbidden",
@@ -29,280 +37,183 @@ const PERMANENT_FAILURE_PATTERNS = [
   "returned 401",
 ];
 
-/** Patterns that indicate a specific tool is unavailable — not worth retrying via HTTP. */
-const TOOL_UNAVAILABLE_PATTERNS = [
-  "tool not available",
-  "returned 404",
-];
-
 function isPermanentHttpFailure(reason: string): boolean {
   const lower = reason.toLowerCase();
   return PERMANENT_FAILURE_PATTERNS.some((p) => lower.includes(p));
 }
 
-function isPermanentHttpStatus(status: number): boolean {
-  return status === 401 || status === 403;
-}
+type ExecBridge = "unknown" | "available" | "unavailable";
 
 export class AutoTransport implements OpenClawClient {
   private cli = new CliTransport();
   private http = new HttpTransport();
-  private preferHttp = false;
-  private lastProbe = 0;
-  private probing: Promise<void> | null = null;
-  // Re-probe quickly after a fallback (3s) so HTTP is rediscovered fast.
-  // Use a longer interval (60s) when the transport is stable.
-  private readonly probeIntervalStableMs = 60_000;
-  private readonly probeIntervalRecoveryMs = 3_000;
-  private readonly probeTimeoutMs = 2_000;
-  private inRecovery = false;
-
-  /** Circuit breaker: once true, HTTP is permanently disabled. */
-  private permanentCliMode = false;
-  private consecutiveHttpFailures = 0;
+  private rpc = getGatewayRpcChannel();
 
   /**
-   * Cache of tools that returned 404 ("Tool not available") via HTTP.
-   * These skip HTTP entirely and go straight to CLI, avoiding wasted
-   * round-trips and CLI queue pressure from fallback pile-ups.
-   * Entries expire after 60s so new gateway deploys are picked up.
+   * Whether `openclaw <cmd>` can be bridged through the gateway's `exec` tool.
+   * Starts unknown, is probed once, then cached — a denied `exec` used to be
+   * rediscovered through a 404 on every single call.
    */
-  private unavailableTools = new Map<string, number>();
-  private readonly toolUnavailableTtlMs = 60_000;
+  private execBridge: ExecBridge = "unknown";
+  private execBridgeCheckedAt = 0;
+  private execProbe: Promise<void> | null = null;
 
-  /** CLI concurrency limiter — prevents subprocess storms during gateway restarts. */
+  /** CLI concurrency guard — prevents subprocess storms during restarts. */
   private activeCli = 0;
   private readonly maxCli = 6;
-
-  /** Check if a tool is known to be unavailable via HTTP (cached 404). */
-  private isToolUnavailable(tool: string): boolean {
-    const ts = this.unavailableTools.get(tool);
-    if (!ts) return false;
-    if (Date.now() - ts > this.toolUnavailableTtlMs) {
-      this.unavailableTools.delete(tool);
-      return false;
-    }
-    return true;
-  }
-
-  /** Mark a tool as unavailable via HTTP after a 404. */
-  private markToolUnavailable(reason: string): void {
-    const lower = reason.toLowerCase();
-    if (TOOL_UNAVAILABLE_PATTERNS.some((p) => lower.includes(p))) {
-      // Extract tool name from error like "Gateway /tools/invoke exec returned 404"
-      const match = reason.match(/\/tools\/invoke\s+(\S+)/);
-      if (match) {
-        this.unavailableTools.set(match[1], Date.now());
-      }
-    }
-  }
-
-  /** Extract the tool name from CLI args (e.g., ["skills", "list"] → "exec"). */
-  private toolForArgs(_args: string[]): string {
-    // All CLI commands go through the "exec" tool on the HTTP transport
-    return "exec";
-  }
 
   getTransport(): TransportMode {
     return "auto";
   }
 
+  /**
+   * Report the channel that carries `openclaw <cmd>` invocations. RPC health is
+   * separate and no longer implied by this value.
+   */
   async resolveTransport(): Promise<TransportMode> {
-    if (this.permanentCliMode) return "cli";
-    await this.probe();
-    return this.preferHttp ? "http" : "cli";
-  }
-
-  private shouldUseHttpForStatus(status: number): boolean {
-    // 404 means "/tools/invoke" is missing; 401/403 means auth rejects requests.
-    // In both cases, command invocation over HTTP won't work.
-    if (status === 404 || status === 401 || status === 403) return false;
-    // Any non-5xx implies the Gateway is reachable and potentially usable.
-    return status < 500;
-  }
-
-  private markHttpFailed(reason: string): void {
-    // Track tool-specific unavailability (e.g., "exec" returning 404).
-    // This prevents repeated HTTP attempts for tools the gateway doesn't support.
-    this.markToolUnavailable(reason);
-
-    const wasHttp = this.preferHttp;
-    this.preferHttp = false;
-    this.consecutiveHttpFailures++;
-
-    // Scope/auth errors are permanent — stop probing.
-    if (isPermanentHttpFailure(reason)) {
-      this.permanentCliMode = true;
-      this.inRecovery = false;
-      console.warn(
-        `[AutoTransport] Permanent CLI mode: ${reason}. HTTP transport disabled for this process.`,
-      );
-      return;
-    }
-
-    this.inRecovery = true;
-    // Force a quick re-probe on the next request.
-    this.lastProbe = Date.now() - this.probeIntervalRecoveryMs;
-    if (wasHttp) {
-      console.warn(`[AutoTransport] HTTP failed, falling back to CLI: ${reason}`);
-    }
-  }
-
-  /** Probe Gateway availability and cache the result. */
-  private async probe(): Promise<void> {
-    // Circuit breaker: don't probe if permanently in CLI mode.
-    if (this.permanentCliMode) return;
-
-    const interval = this.inRecovery
-      ? this.probeIntervalRecoveryMs
-      : this.probeIntervalStableMs;
-    if (Date.now() - this.lastProbe < interval) return;
-    // Deduplicate concurrent probes.
-    if (this.probing) return this.probing;
-    this.probing = (async () => {
-      const hadHttp = this.preferHttp;
-      try {
-        // Probe with a real POST to catch scope errors (HEAD bypasses auth).
-        const res = await this.http.gatewayFetch("/tools/invoke", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ tool: "sessions_list", input: {} }),
-          signal: AbortSignal.timeout(this.probeTimeoutMs),
-        });
-
-        // Check for permanent auth/scope failures on probe.
-        if (isPermanentHttpStatus(res.status)) {
-          const body = await res.text().catch(() => "");
-          this.markHttpFailed(
-            `HTTP ${res.status} during probe${body ? `: ${body.slice(0, 200)}` : ""}`,
-          );
-          return;
-        }
-
-        const allowHttp = this.shouldUseHttpForStatus(res.status);
-        this.preferHttp = allowHttp;
-        this.inRecovery = !allowHttp;
-
-        if (allowHttp) {
-          this.consecutiveHttpFailures = 0;
-        }
-
-        if (allowHttp && !hadHttp) {
-          console.info("[AutoTransport] HTTP transport restored.");
-        }
-        if (!allowHttp && hadHttp) {
-          console.warn(
-            `[AutoTransport] Probe switched to CLI fallback (HTTP ${res.status}).`,
-          );
-        }
-      } catch (err) {
-        this.markHttpFailed(errorToMessage(err));
-      } finally {
-        this.lastProbe = Date.now();
-        this.probing = null;
-      }
-    })();
-    return this.probing;
-  }
-
-  private async pick(): Promise<OpenClawClient> {
-    if (this.permanentCliMode) return this.cli;
-    await this.probe();
-    return this.preferHttp ? this.http : this.cli;
+    await this.probeExecBridge();
+    return this.execBridge === "available" ? "http" : "cli";
   }
 
   /**
-   * Execute with automatic fallback on HTTP failure.
-   * Skips HTTP entirely for tools known to be unavailable (cached 404).
+   * Establish whether the gateway exposes `exec` over `POST /tools/invoke`.
+   *
+   * `exec` is on OpenClaw's default HTTP deny list, so on a stock install this
+   * settles on "unavailable" once and stays there for the TTL instead of
+   * failing one call at a time.
    */
-  private async withFallback<T>(
-    fn: (client: OpenClawClient) => Promise<T>,
-    tool?: string,
-  ): Promise<T> {
-    // If this tool is known to be unavailable via HTTP, skip straight to CLI.
-    if (tool && this.isToolUnavailable(tool)) {
-      return fn(this.cli);
+  private async probeExecBridge(): Promise<void> {
+    if (this.execBridge !== "unknown" && Date.now() - this.execBridgeCheckedAt < EXEC_BRIDGE_TTL_MS) {
+      return;
     }
-    const primary = await this.pick();
-    try {
-      return await fn(primary);
-    } catch (err) {
-      if (primary === this.http) {
-        this.markHttpFailed(errorToMessage(err));
-        // CLI fallback — the underlying CLI semaphore handles queuing.
-        // Only hard-reject if we're way over capacity to prevent OOM.
-        if (this.activeCli >= this.maxCli) {
-          throw new Error("Gateway busy — too many pending CLI operations");
+    if (this.execProbe) return this.execProbe;
+
+    this.execProbe = (async () => {
+      try {
+        const res = await this.http.gatewayFetch("/tools/invoke", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          // A no-op command: enough to learn whether the tool is exposed at all
+          // without depending on the host's shell environment.
+          body: JSON.stringify({ tool: "exec", args: { command: "true" }, action: "json" }),
+          signal: AbortSignal.timeout(4_000),
+        });
+        const previous = this.execBridge;
+        if (res.status === 200) {
+          this.execBridge = "available";
+          if (previous !== "available") {
+            console.info("[AutoTransport] Gateway exec bridge available over HTTP.");
+          }
+        } else {
+          this.execBridge = "unavailable";
+          if (previous === "unknown") {
+            const detail =
+              res.status === 404
+                ? "exec is not exposed on POST /tools/invoke (OpenClaw denies it by default)"
+                : `HTTP ${res.status}`;
+            console.info(`[AutoTransport] Running openclaw via local CLI: ${detail}.`);
+          }
         }
-        this.activeCli++;
-        try {
-          return await fn(this.cli);
-        } finally {
-          this.activeCli--;
-        }
+      } catch (err) {
+        this.execBridge = "unavailable";
+        console.info(
+          `[AutoTransport] Running openclaw via local CLI: gateway HTTP probe failed (${errorToMessage(err)}).`,
+        );
+      } finally {
+        this.execBridgeCheckedAt = Date.now();
+        this.execProbe = null;
       }
-      throw err;
+    })();
+
+    return this.execProbe;
+  }
+
+  private markExecBridgeUnavailable(reason: string): void {
+    if (this.execBridge === "available") {
+      console.warn(`[AutoTransport] Gateway exec bridge failed, using local CLI: ${reason}`);
+    }
+    this.execBridge = "unavailable";
+    this.execBridgeCheckedAt = Date.now();
+  }
+
+  /** Pick the channel for `openclaw <cmd>` invocations. */
+  private async pickCommandChannel(): Promise<OpenClawClient> {
+    await this.probeExecBridge();
+    return this.execBridge === "available" ? this.http : this.cli;
+  }
+
+  /** Run a command, falling back from the HTTP bridge to a local subprocess. */
+  private async withFallback<T>(fn: (client: OpenClawClient) => Promise<T>): Promise<T> {
+    const primary = await this.pickCommandChannel();
+    if (primary === this.cli) return fn(this.cli);
+
+    try {
+      return await fn(this.http);
+    } catch (err) {
+      const reason = errorToMessage(err);
+      this.markExecBridgeUnavailable(reason);
+      if (isPermanentHttpFailure(reason)) {
+        // Auth/scope mismatches never fix themselves within the TTL.
+        this.execBridgeCheckedAt = Date.now();
+      }
+      if (this.activeCli >= this.maxCli) {
+        throw new Error("Gateway busy — too many pending CLI operations");
+      }
+      this.activeCli++;
+      try {
+        return await fn(this.cli);
+      } finally {
+        this.activeCli--;
+      }
     }
   }
 
   // ── OpenClawClient interface ──────────────────────
 
   runJson<T>(args: string[], timeout?: number): Promise<T> {
-    return this.withFallback((c) => c.runJson<T>(args, timeout), this.toolForArgs(args));
+    return this.withFallback((c) => c.runJson<T>(args, timeout));
   }
 
   run(args: string[], timeout?: number, stdin?: string): Promise<string> {
-    return this.withFallback((c) => c.run(args, timeout, stdin), this.toolForArgs(args));
+    return this.withFallback((c) => c.run(args, timeout, stdin));
   }
 
   async runCapture(args: string[], timeout?: number): Promise<RunCliResult> {
-    const tool = this.toolForArgs(args);
+    const primary = await this.pickCommandChannel();
+    if (primary === this.cli) return this.cli.runCapture(args, timeout);
 
-    // If tool is known-unavailable via HTTP, or we're in permanent CLI mode, skip HTTP.
-    if (this.permanentCliMode || this.isToolUnavailable(tool)) {
+    const result = await this.http.runCapture(args, timeout);
+    if (result.code !== 0 && result.stderr?.includes("/tools/invoke")) {
+      this.markExecBridgeUnavailable(result.stderr);
       return this.cli.runCapture(args, timeout);
     }
-    await this.probe();
-    if (this.preferHttp) {
-      const result = await this.http.runCapture(args, timeout);
-      if (result.code !== 0 && result.stderr?.includes("/tools/invoke")) {
-        this.markHttpFailed(result.stderr || `openclaw ${args.join(" ")} failed over HTTP`);
-        return this.cli.runCapture(args, timeout);
-      }
-      return result;
-    }
-    // CLI-only path — let the CLI semaphore handle queuing.
-    return this.cli.runCapture(args, timeout);
+    return result;
   }
 
-  async gatewayRpc<T>(
-    method: string,
-    params?: Record<string, unknown>,
-    timeout?: number,
-  ): Promise<T> {
-    // gatewayRpc uses WebSocket/HTTP RPC — CLI fallback does not help here
-    // (the CLI would spawn a new gateway process or timeout). Fail fast and let
-    // callers serve stale cache instead of spawning an expensive subprocess.
-    await this.probe();
-    if (this.preferHttp) {
-      return this.http.gatewayRpc<T>(method, params, timeout);
-    }
-    throw new Error(`Gateway RPC unavailable for ${method} — gateway is not reachable via HTTP`);
+  /**
+   * Gateway RPC rides its own WebSocket channel with a CLI fallback, so it stays
+   * available even when the HTTP `exec` bridge is denied.
+   */
+  gatewayRpc<T>(method: string, params?: Record<string, unknown>, timeout?: number): Promise<T> {
+    return this.rpc.request<T>(method, params ?? {}, timeout);
   }
 
+  // File operations run against the local filesystem: Mission Control is a
+  // local dashboard, and the gateway does not expose filesystem tools over
+  // HTTP (fs_write and friends are denied, and `read`/`write` are not tools).
   readFile(path: string): Promise<string> {
-    return this.withFallback((c) => c.readFile(path));
+    return this.cli.readFile(path);
   }
 
   writeFile(path: string, content: string): Promise<void> {
-    return this.withFallback((c) => c.writeFile(path, content));
+    return this.cli.writeFile(path, content);
   }
 
   readdir(path: string): Promise<string[]> {
-    return this.withFallback((c) => c.readdir(path));
+    return this.cli.readdir(path);
   }
 
   async gatewayFetch(path: string, init?: RequestInit): Promise<Response> {
-    return this.withFallback((c) => c.gatewayFetch(path, init));
+    return this.http.gatewayFetch(path, init);
   }
 }

--- a/src/lib/transports/http-transport.ts
+++ b/src/lib/transports/http-transport.ts
@@ -8,18 +8,21 @@
  * Auth: Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>
  */
 
-import { getGatewayUrl } from "../paths";
-import { GatewayRpcClient } from "../gateway-rpc";
+import { getGatewayPassword, getGatewayToken, getGatewayUrl } from "../paths";
+import { GatewayRpcChannel } from "../gateway-rpc-channel";
 import { parseJsonFromCliOutput, type RunCliResult } from "../openclaw-cli";
 import type { OpenClawClient, TransportMode } from "../openclaw-client";
 
 export class HttpTransport implements OpenClawClient {
   private token: string;
   private gatewayUrlCache: string | null = null;
-  private rpcClient: GatewayRpcClient | null = null;
+  private rpcChannel: GatewayRpcChannel | null = null;
 
   constructor(gatewayUrl?: string, token?: string) {
-    this.token = token || process.env.OPENCLAW_GATEWAY_TOKEN || "";
+    // Fall back to openclaw.json, not just the env var: token mode usually
+    // stores the secret in `gateway.auth.token`, and password mode has no token
+    // at all. Either shared secret authenticates this host as a local operator.
+    this.token = token || getGatewayToken() || getGatewayPassword();
     this.gatewayUrlCache = gatewayUrl || null;
   }
 
@@ -173,28 +176,39 @@ export class HttpTransport implements OpenClawClient {
     params?: Record<string, unknown>,
     timeout = 15000,
   ): Promise<T> {
-    if (!this.rpcClient) {
-      this.rpcClient = new GatewayRpcClient(this.gatewayUrlCache || undefined, this.token);
+    // Gateway RPC is a WebSocket protocol; it is only reached from here because
+    // this class is also the "remote gateway" transport. The channel handles
+    // connection reuse and the CLI fallback.
+    if (!this.rpcChannel) {
+      this.rpcChannel = new GatewayRpcChannel(this.gatewayUrlCache || undefined, this.token);
     }
-    return this.rpcClient.request<T>(method, params || {}, timeout);
+    return this.rpcChannel.request<T>(method, params || {}, timeout);
+  }
+
+  /**
+   * The gateway deliberately exposes no filesystem tools on
+   * `POST /tools/invoke` — `fs_write`, `fs_delete`, `fs_move` and `apply_patch`
+   * are on its default deny list, and there is no `read`/`write` tool to call.
+   * Say so instead of returning a 404 from a generic tool invocation.
+   */
+  private unsupportedFileOperation(operation: string): Error {
+    return new Error(
+      `Cannot ${operation} over the gateway HTTP transport: OpenClaw does not expose ` +
+        "filesystem tools on POST /tools/invoke. Run Mission Control on the gateway host " +
+        "with OPENCLAW_TRANSPORT=auto (or cli) so file access uses the local filesystem.",
+    );
   }
 
   async readFile(path: string): Promise<string> {
-    const result = await this.invoke<
-      { content?: string; output?: string; details?: unknown; text?: string } | string
-    >("read", { path });
-    if (typeof result === "string") return result;
-    if (typeof result.content === "string") return result.content;
-    return this.resultToText(result);
+    throw this.unsupportedFileOperation(`read ${path}`);
   }
 
-  async writeFile(path: string, content: string): Promise<void> {
-    await this.invoke("write", { path, content });
+  async writeFile(path: string): Promise<void> {
+    throw this.unsupportedFileOperation(`write ${path}`);
   }
 
   async readdir(path: string): Promise<string[]> {
-    const raw = await this.execCommand(`ls -1 "${path}"`);
-    return raw.split("\n").filter(Boolean);
+    throw this.unsupportedFileOperation(`list ${path}`);
   }
 
   async gatewayFetch(path: string, init?: RequestInit): Promise<Response> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Audits the OpenClaw integration against a live **OpenClaw 2026.7.1-2** gateway and fixes what no longer works. Every finding below was reproduced against a running gateway rather than inferred from docs, and every fix was re-verified the same way.

## Why the dashboard was dead, not just degraded

Two independent failures each broke the entire control plane:

**The handshake was rejected outright.** Mission Control advertised protocol `[3, 3]`. OpenClaw's `MIN_CLIENT_PROTOCOL_VERSION` is now `4`, and its N-1 compatibility window covers only `role: "node"` clients and restart probes — an operator client must advertise `4` exactly. The gateway answered `PROTOCOL_MISMATCH` and closed the socket.

**The client identity silently forfeited all permissions.** Even at protocol 4, the `("cli", "backend")` identity was granted **zero scopes**, so every call failed with `missing scope: operator.read`. The gateway preserves a scope request from an unpaired client for exactly two identity pairs; the one meaning "a local backend service" is `("gateway-client", "backend")`. This is silent — the handshake succeeds and only later calls fail.

Both are now pinned in `src/lib/gateway-protocol.ts`, which documents why each value is load-bearing so a future bump does not undo it.

**RPC was also hostage to an unrelated HTTP probe.** Config, sessions, cron, usage and skills all rode the HTTP transport, whose health was decided by a `POST /tools/invoke` probe calling `exec`. Current OpenClaw denies `exec` on that endpoint by default, so the probe now fails on *every healthy install* and disabled the dashboard with it. The gateway's RPC surface is a WebSocket protocol; it now owns its own connection and health (`gateway-rpc-channel.ts`), falling back to `openclaw gateway call` only when the socket itself is unusable.

This last one is the single most reported symptom. `Gateway RPC unavailable for <method> — gateway is not reachable via HTTP` was filed three separate times against three different pages (#75 `config.get`, #76 `config.get` from the Vector DB tab, #85 `sessions.list` from Usage). All three are the same root cause and all three are fixed by the same change.

## Correctness bugs found while auditing

**Requirement installs ran the wrong package on the wrong host.** The install route ran `brew install <bin>` locally. A skill's install spec names a formula distinct from the binaries it provides — 1password's is `1password-cli`, providing `op` — so this installed the wrong thing. OpenClaw's inventory API sanitizes `formula` out *precisely* so callers use `skills.install`, which picks the installer per host across brew, uv, the configured node manager, go and download, and installs where the agent will actually look. The UI also gated the button on `kind` being brew, npm or pip; of the kinds a stock install offers (brew, go, node, uv, download) npm and pip never appear, so half the options rendered as un-runnable "Manual".

**Toggling one skill restarted the gateway.** Enable/disable went through `config.patch` with `restartDelayMs`, dropping every live session to flip a switch. `skills.update` writes the same key and applies it in place — now ~140ms, socket stays connected.

**The workspace path was a guess that could not be right.** Resolved as `$OPENCLAW_HOME/workspace`, but OpenClaw names each agent's directory after its id (`workspace-dev` for the default agent `dev`), and the id is not derivable from the path. Consequences, both confirmed live: the ClawHub tab reported nothing installed because it looked for the lockfile in the wrong place, and uninstall reported success while deleting nothing. Now sourced from `agents.list`.

**Ambiguous ClawHub slugs.** Slugs are not unique per owner — "weather" matches several published skills — and the registry rejects a bare one with `AMBIGUOUS_SKILL_SLUG`. Catalog rows now carry the qualified `@owner/slug`, install prefers it, and it is the React key (three same-slug results previously collided on one).

**The timezone preference wrote to a key that does not exist.** Preferences patched `settings.timezone`, but `settings` is not one of the schema's 45 top-level keys, so the gateway rejected the entire patch with `invalid config: <root>: Unrecognized key: "settings"`. Mission Control then spent ~50s running doctor to repair a config that was never broken, and still failed. The read path was wrong the same way, so the field also always rendered empty. Timezone lives at `agents.defaults.envelopeTimezone`; saving now succeeds in ~200ms and reads back. Every other dotted config path the repo touches was checked against the live schema — 49 of 50 were already correct, and this was the only bad one.

**Two CLI commands print their payload to stderr.** `runCliJson` only consulted stderr when the process *failed*, because that is the only case where the rejected error carries the streams. `browser extension path` and `browser extension pair` both exit 0 while writing to stderr, so they parsed empty stdout and returned nothing — with no error to explain it. Both streams are now searched regardless of exit code. This was the whole reason the extension panel showed a blank path and "unknown" manifest on a healthy install; a sweep of every read-only `--json` command the repo uses confirmed these two are the only ones affected.

**`browser extension install` does not exist.** The "Install Extension" button always failed with `OpenClaw does not know the command "install"`. The unpacked extension ships inside the OpenClaw package and is loaded by hand in Chrome — what cannot be done by hand is minting the relay pairing secret. The action is now `browser extension pair`, which returns the pairing string, and the setup copy follows the documented load-unpacked-then-pair flow. Relatedly, `browser` is a bundled *plugin* command that is not registered at all without a `browser` config block, which surfaced as a raw unknown-command error; that now explains the actual fix.

## Smaller compatibility fixes

- **Liveness probed the wrong endpoint.** `GET /` reports a healthy gateway as offline whenever the Control UI is disabled, proxied or auth-gated. `GET /health` is documented for exactly this, needs no auth and creates no session, with a root-probe fallback for older builds. (#80)
- **`pairing list` now requires `--channel`.** Channel-less calls failed and filled gateway logs with stack traces. The route enumerates configured channels and accounts via `channels.status` and asks per channel. (#84)
- **The ClawHub tab required a second binary.** It shelled out to a standalone `clawhub` CLI, disabling itself entirely when absent — including actions that never needed it — and scraped slugs out of a table with regexes. Search, inspect, install, update and installed-list now go through the gateway. Only query-less browsing still needs the binary (`skills.search` requires a query); that degrades to a note pointing at search instead of disabling the tab.
- **Skills cost three subprocesses.** Each `skills.status` row carries the full `skills info` field set, so one snapshot answers list, check and every detail view. The page fetches list and check together and paid ~5s of subprocess spawns before rendering; it now answers in ~70ms. The check payload is also realigned with 2026.7: `missing` is a requirements object rather than a flat list, and `modelVisible`, `commandVisible`, `agentFiltered` and `notInjected` are new buckets — verified bucket-for-bucket against `openclaw skills check --json` on a 53-skill install. (#68, #73, #78)
- **Config writes could be aborted mid-write.** A 15s budget (8s for the post-update write) is not enough on a cold plugin cache, so writes that had already landed reported failure. (#82)
- **The tasks board clipped its own cards.** Each column was meant to scroll, but the row holding them had an auto height, so columns stretched to the tallest instead of being bounded by the board — the per-column scroll never engaged and the board's `overflow-y-hidden` swallowed everything past the fold, with no scrollbar and a dead wheel. Below `md` the columns stack, where a horizontal-only board cannot work at all, so the board scrolls vertically there. (#77)

## Verification

`tsc --noEmit`, ESLint and the production build all pass. ESLint errors went from 7 to 6 (one pre-existing restricted-import cleared).

Against a live 2026.7.1-2 gateway: a 36-route GET sweep returns 200 with no error, warning or degraded flag on any route except `/api/tailscale`, which correctly reports that the `tailscale` binary is absent from the test host. Also exercised end-to-end: skills list/check/info, the full ClawHub install → list → uninstall cycle with **no `clawhub` binary present**, a real `node`-kind requirement install on Linux, skill toggling with no restart, `/health` liveness, the Vector DB local-provider enable that #76 reported, a real timezone save round-trip, and the browser extension path and pairing actions.

The CLI surface was checked rather than assumed: `openclaw --help` was walked recursively into a 450-command tree and every command, subcommand and flag the repo invokes was validated against it, as was every dotted config path against `config.schema`.

## Issue status

Fixed and verified live on this branch:

| Issue | Root cause |
|---|---|
| #75, #76, #85 | RPC held hostage by the HTTP `exec` probe |
| #80 | liveness probed `/` instead of `/health` |
| #84 | `pairing list` requires `--channel` |
| #68, #73 | skills read through the CLI instead of `skills.status` |
| #78 | skill detail rendered an error payload as data |
| #82 | config-write timeout too small for a cold plugin cache |
| #77 | tasks board clipped instead of scrolling |

Not addressed here, with reasons:

- **#70 (local-only models)** asks OpenClaw itself for a way to run without paid provider keys. Mission Control's own gate already accepts a local setup: it treats any `models.providers.*.baseUrl` entry, or a reachable Ollama on `:11434`, as sufficient credentials, and that path is valid against the current schema. Nothing in this audit blocks a local-only install.
- **#81 (agents panel not scrollable on mobile)** is a layout question about the default Hierarchy view, which is a ReactFlow pan/zoom canvas where `overflow-hidden` is correct by design; the Cards view scrolls properly. Changing which view mobile defaults to is a UX decision rather than a compatibility fix, so it is left for a separate change.
- **#86** is a partnership enquiry, not a defect.

## Release

Tagged for **v0.6.0**. `package.json` had drifted to `0.4.9` while `v0.5.1` was the published release, so the version reported at handshake and shown in the UI was two releases stale; it is now back in step. A `CHANGELOG.md` is added because `release.yml` otherwise generates notes from commit titles alone.

To publish after merge: `git tag v0.6.0 && git push origin v0.6.0` — the release workflow does the rest.

Two notes for reviewers. `skills.detail` and `skills.search` are *registry* methods keyed by `slug`, not the local detail/list methods — a trap worth knowing, and called out in the code. And `skills.install` answers once instead of streaming, so install output now arrives in one batch; the SSE envelope is kept so the terminal view is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe67d-bc1a-7aee-9cb3-b53edb116589?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe67d-bc1a-7aee-9cb3-b53edb116589&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

