### PR TITLE
docs: audit open GitHub issues with draft replies and close plans

### DIFF
--- a/docs/issue-audit/IMPLEMENTATION.md
+++ b/docs/issue-audit/IMPLEMENTATION.md
@@ -1,0 +1,106 @@
+# Implementation plans for issues that stay open
+
+These are engineering plans only — nothing was closed or implemented in this audit PR.
+
+## #70 — Local-only models (P0 feature)
+
+### Goal
+
+A user on a DGX Spark / air-gapped box can run Mission Control end-to-end on Ollama, LM Studio, vLLM, or a custom OpenAI-compatible server without ever pasting a cloud API key — and adding a cloud key later must not steal `agents.defaults.model.primary`.
+
+### Align with OpenClaw
+
+- Docs: [Local models](https://docs.openclaw.ai/gateway/local-models), [Ollama](https://docs.openclaw.ai/providers/ollama)
+- Write `models.providers.<id>` with loopback `baseUrl` + non-secret marker (`ollama-local`, `lmstudio`, `sk-local`)
+- Set `agents.defaults.model.primary` to `provider/model`
+- Prefer `config.patch` over `openclaw config set` (already the house style post-#82)
+- Surface `timeoutSeconds` and optional `localModelLean` for smaller GPUs
+
+### Touch points
+
+| Area | Files |
+|------|-------|
+| Onboarding UI | `src/components/onboarding/step-model.tsx`, wizard types |
+| Onboarding API | `src/app/api/onboarding/model-auth/route.ts`, `src/app/api/onboard/route.ts` |
+| Models UI | `src/components/models-view.tsx` |
+| Models API | `src/app/api/models/route.ts` (`LOCAL_PROVIDERS` already exists) |
+| Auth helpers | `src/lib/provider-auth.ts` — allow keyless local probe |
+| Doctor | local server reachability check |
+
+### UX sketch
+
+1. Provider chooser: **Local** | Cloud | Subscription
+2. Local sub-chooser: Ollama (auto-detect `:11434`) | LM Studio (`:1234`) | Custom URL
+3. Probe → model picker → Save as primary
+4. Advanced: contextWindow, maxTokens, api mode, timeoutSeconds, lean mode toggle
+
+### Tests
+
+- Unit: config patch shape for ollama / lmstudio / custom
+- e2e (mocked): onboarding completes without token; primary preserved when cloud key added later
+
+---
+
+## #77 — Tasks scroll (P1 bug)
+
+### Goal
+
+Desktop kanban columns scroll independently when cards overflow; page does not silently eat wheel events.
+
+### Fix sketch
+
+In `tasks-view.tsx` board region:
+
+1. Outer: keep `md:overflow-y-hidden` only if children are height-bound
+2. Grid: `md:h-full md:min-h-0` + `items-stretch` (not `items-start`)
+3. Column shell: `md:h-full md:min-h-0 flex flex-col`
+4. Card list: existing `flex-1 overflow-y-auto min-h-0` then works
+
+Add Playwright assertion with many cards.
+
+---
+
+## #81 — Agents fleet accessibility (P1 UX)
+
+### Goal
+
+On a phone, every agent is reachable without secret gestures.
+
+### Fix sketch
+
+1. Default `viewMode` to `grid` when `window.matchMedia('(max-width: 768px)')` or via UA on first paint; honor `?view=`
+2. Hierarchy: on mount `fitView`, show transient hint “Drag to pan · pinch to zoom”
+3. New compact **Fleet** list (optional third mode): virtualized rows, search, status chips — maximum operator power for large orgs
+4. Persist preference in `localStorage`
+
+---
+
+## #73 residual — CLI JSON without TTY (P2)
+
+### Goal
+
+Skills (and any `runCliJson` consumer) survive exit-0 empty-stdout stderr-JSON.
+
+### Fix sketch
+
+In `src/lib/openclaw-cli.ts`:
+
+- Prefer `runCliCaptureBoth` inside `runCliJson`
+- If stdout has no JSON, parse stderr before throwing “empty output”
+- Optionally set `FORCE_COLOR=0` (already `NO_COLOR`) and document headless behavior in Doctor
+
+Keep RPC `skills.status` as primary.
+
+---
+
+## #80 reindex follow-up (P2)
+
+### Goal
+
+Reindex failures explain themselves and never look like “gateway offline”.
+
+### Fix sketch
+
+- `/api/vector` reindex: catch tool/CLI errors → `400/422` with `{ ok:false, code, message, fixHint }`
+- UI maps codes to CTAs (pull embedding model, start Ollama, enable local plugin)
+- Preflight uses existing provider availability from status payload

--- a/docs/issue-audit/README.md
+++ b/docs/issue-audit/README.md
@@ -1,0 +1,51 @@
+# Open GitHub Issue Audit — Mission Control `v0.9.0`
+
+Audit date: 2026-08-10  
+Repo: `robsannaa/openclaw-mission-control`  
+OpenClaw docs consulted: [docs.openclaw.ai](https://docs.openclaw.ai/), [local models](https://docs.openclaw.ai/gateway/local-models), [Ollama](https://docs.openclaw.ai/providers/ollama), [pairing](https://docs.openclaw.ai/channels/pairing), [configuration / config.get](https://docs.openclaw.ai/gateway/configuration)
+
+**Do not close any issues from this audit alone.** Draft replies live in [`drafts/`](./drafts/). Use them after a human reviews tone and any remaining repro.
+
+## Triage summary
+
+| # | Title | Verdict | Disposition |
+|---|-------|---------|-------------|
+| 70 | Unable to use local only models | **Valid feature gap** | Keep open → implement local-first model path |
+| 73 | Skills empty output / always Degraded (no TTY) | **Mostly fixed; residual edge** | Keep open → harden CLI stderr recovery; close after verify |
+| 75 | Gateway RPC unavailable for config.get | **Fixed in v0.9.0 / #87** | Close as fixed after ask reporter to upgrade |
+| 76 | Can't add vector db | **Same root as #75** | Close as fixed (duplicate) after verify; keep vector UX notes |
+| 77 | Unable to scroll on tasks page | **Valid / likely regressed** | Keep open → restore column height binding |
+| 78 | Skill detail crash (`bins` undefined) | **Fixed on main** | Close as fixed after ask reporter to upgrade |
+| 80 | Gateway offline while online + vector reindex 500 | **Mostly fixed; reindex still fragile** | Split: close gateway half; keep/track reindex |
+| 81 | Agent fleet panel not scrollable | **Valid UX gap** | Keep open → mobile-friendly fleet list + pan affordance |
+| 82 | save-and-restart 15s CLI timeout | **Fixed on main** | Close as fixed after ask reporter to upgrade |
+| 84 | pairing list requires `--channel` | **Fixed on main** | Close as fixed after ask reporter to upgrade |
+| 85 | Usage not working | **Same root as #75** | Close as fixed (duplicate) after upgrade + retest |
+| 86 | Partnership inquiry (MyClaw.ai) | **Not a product bug** | Close as support/off-topic → private reply |
+
+## Cross-cutting findings (codebase)
+
+Mission Control is a thin local window into OpenClaw (`~/.openclaw`, gateway WS RPC, CLI). Power for users grows when every screen:
+
+1. Prefers **Gateway RPC** (`config.get` / `config.patch` / `skills.status` / `sessions.list` / `channels.status`) over cold CLI.
+2. Treats **local providers** (Ollama, LM Studio, vLLM, custom OpenAI-compatible) as first-class, not an afterthought behind API-key wizards.
+3. Never conflates **RPC health** with **HTTP `/tools/invoke` exec** (fixed in #87 / `auto-transport.ts`).
+4. Survives **headless / no-TTY** service installs (`TERM=dumb`, stderr JSON, missing requirement bags).
+5. Keeps layout **scrollable on mobile** when canvases or kanban columns exceed the viewport.
+
+Relevant support range today: OpenClaw `>=2026.7.0 <2026.9.0` (`src/lib/gateway-protocol.ts`). Package version: `0.9.0`.
+
+## Priority order if implementing next
+
+1. **#70 Local-only models** — biggest user-power unlock; aligns with OpenClaw docs.
+2. **#77 Tasks scroll** + **#81 Agents fleet scroll** — small UI fixes, high daily friction.
+3. **#73 residual CLI stderr** — harden `runCliJson` for exit-0 + stderr JSON.
+4. **#80 reindex path** — clearer errors + memory RPC preference when available.
+5. Close the already-fixed cluster (**#75, #76, #78, #82, #84, #85**) with upgrade notes.
+6. Handle **#86** privately; close as non-bug.
+
+## Drafts
+
+Ready-to-post GitHub comments (not posted by this audit):
+
+- [`drafts/70.md`](./drafts/70.md) … [`drafts/86.md`](./drafts/86.md)

--- a/docs/issue-audit/drafts/70.md
+++ b/docs/issue-audit/drafts/70.md
@@ -1,0 +1,51 @@
+## Draft reply for #70 — Unable to use local only models
+
+**Status:** Valid feature request / product gap. Keep open.
+
+### Analysis
+
+Reporter wants a fully offline / DGX Spark setup with local models only — no OpenRouter / OpenAI / Anthropic. Owner already acknowledged this as a larger feature.
+
+On `main` (v0.9.0):
+
+- Onboarding `StepModel` only offers cloud providers + API key / subscription token (`src/components/onboarding/step-model.tsx`).
+- Models “Connect provider” still expects a token for `auth-provider`.
+- Ambient Ollama detection exists in `/api/onboard` (`hasOllama` via `http://127.0.0.1:11434/api/tags`) but is informational only.
+- Agents model picker already labels Ollama as “Local — no key needed”, so runtime awareness exists unevenly.
+
+OpenClaw officially supports this path:
+
+- https://docs.openclaw.ai/gateway/local-models
+- https://docs.openclaw.ai/providers/ollama
+
+Local / loopback providers accept a non-secret marker (`apiKey: "ollama-local"`, `"lmstudio"`, etc.) when `baseUrl` is private. Mission Control should write that config instead of forcing a paid key.
+
+Community report in-thread: providing an OpenRouter key to “bypass” the wizard overwrote their local primary model — that is a real footgun and must be part of the fix.
+
+### Proposed solution (user-power oriented)
+
+Ship a **Local models** first-class path end-to-end:
+
+1. **Onboarding step**
+   - Detect Ollama / LM Studio / custom OpenAI-compatible endpoints.
+   - List models from the local server (`/api/tags` or `/v1/models`).
+   - Write provider block via `config.patch` with local marker key + `agents.defaults.model.primary`.
+   - Offer optional hosted fallbacks; never force them.
+
+2. **Models page**
+   - “Connect local provider” wizard: base URL, API style (`ollama` / `openai-completions` / `openai-responses`), timeoutSeconds (local cold-start), probe, set primary.
+   - Preserve existing local primary when connecting a cloud key (explicit “keep primary” checkbox, default on).
+
+3. **Doctor / Dashboard**
+   - Health check: local server reachable + model loaded + context window sane.
+   - One-click “use local lean mode” link to OpenClaw’s `localModelLean` guidance for smaller GPUs.
+
+4. **Safety**
+   - Never silently rewrite `agents.defaults.model.primary` when adding a second provider.
+   - Surface OpenClaw’s local-model security notes (prompt injection / smaller models).
+
+### Acceptance
+
+- Fresh install can complete onboarding with only Ollama/LM Studio/custom local.
+- Existing local-primary configs survive cloud-key add flows.
+- Chat / agents / usage show the local model as primary without requiring paid credentials.

--- a/docs/issue-audit/drafts/73.md
+++ b/docs/issue-audit/drafts/73.md
@@ -1,0 +1,28 @@
+## Draft reply for #73 — Skills empty output / always Degraded (no TTY)
+
+**Status:** Mostly addressed on v0.9.0; keep open until residual CLI path is hardened + reporter verifies.
+
+### Analysis
+
+Root cause: headless Mission Control spawns OpenClaw CLI without a TTY (`TERM=dumb`, piped stdio). Older flows used `openclaw skills … --json`; some builds print JSON on stderr or return empty stdout → UI shows every skill as Degraded.
+
+On `main` (v0.9.0):
+
+- Preferred path is Gateway RPC `skills.status` (`src/lib/skills-status.ts`) — no TTY needed.
+- Requirements bags are normalized so missing `bins` cannot crash render.
+- CLI remains a fallback when RPC is unreachable.
+- Residual gap: `runCliJson` recovers stderr JSON mainly on **non-zero** exit; exit `0` + empty stdout + JSON-on-stderr can still yield “empty output”.
+
+### Proposed solution
+
+1. Ask reporter to upgrade to **≥ 0.9.0** and confirm Skills with a live gateway.
+2. If still broken with RPC healthy → bug in `skills.status` parsing; investigate payload shape.
+3. If broken only when RPC is down → harden `runCliJson` / `runCliCaptureBoth` to always merge stderr when stdout is empty, regardless of exit code.
+4. UI: when inventory source is filesystem-degraded, show “Limited inventory (gateway offline)” instead of marking every skill Degraded — preserves user trust.
+
+### Close plan
+
+Close after:
+
+- Reporter confirms Skills Ready/Needs setup states with RPC path, **or**
+- Residual stderr fix lands and is verified headless under systemd/Docker.

--- a/docs/issue-audit/drafts/75.md
+++ b/docs/issue-audit/drafts/75.md
@@ -1,0 +1,23 @@
+## Draft reply for #75 — Gateway RPC unavailable for config.get (HTTP)
+
+**Status:** Fixed in v0.9.0 (PR #87). Candidate to close after upgrade confirmation.
+
+### Analysis
+
+Error text: `Gateway RPC unavailable for config.get — gateway is not reachable via HTTP`.
+
+OpenClaw’s control plane is a **WebSocket RPC** surface (`config.get`, `config.patch`, …), not HTTP `/tools/invoke`. Older Mission Control probed HTTP exec availability and treated denial/404 as “gateway unreachable”, even when the gateway was healthy. OpenClaw also denies `exec` on that HTTP tool endpoint by default.
+
+Fixed on main by splitting channels:
+
+- WS RPC (+ CLI `gateway call` fallback) for config/sessions/skills/usage
+- Subprocess CLI for `openclaw <cmd>` unless HTTP exec is explicitly available
+
+See `src/lib/transports/auto-transport.ts`, `src/lib/gateway-rpc-channel.ts`, `src/lib/gateway-liveness.ts` (`GET /health`).
+
+### Close plan
+
+1. Ask reporter to update Mission Control to **≥ 0.9.0** and OpenClaw to a supported **2026.7.x** build.
+2. Confirm Doctor/Gateway shows online and Config loads.
+3. If still failing: collect `/api/status`, gateway URL/auth mode, and whether device pairing is pending (428) — do **not** reopen as the same HTTP conflation bug without evidence.
+4. Close as completed once confirmed (or after N days with no reply, note “fixed on main; reopen if repro on 0.9+”).

--- a/docs/issue-audit/drafts/76.md
+++ b/docs/issue-audit/drafts/76.md
@@ -1,0 +1,19 @@
+## Draft reply for #76 — Can't add vector db
+
+**Status:** Same root cause as #75 for Enable failure. Candidate duplicate close after upgrade; keep any post-upgrade reindex failures under #80.
+
+### Analysis
+
+Repro: Vectors → Local (Offline) → Enable →  
+`Gateway RPC unavailable for config.get — gateway is not reachable via HTTP`.
+
+Vector enable needs `config.get` / patch (`src/app/api/vector/route.ts`). That failed for the same HTTP-vs-RPC conflation fixed in #87 / v0.9.0.
+
+OpenClaw memory/embeddings still need a reachable gateway + embedding provider (local plugin, Ollama embedding model, or cloud). Local offline mode is valid when the gateway can write config.
+
+### Close plan
+
+1. Treat as duplicate of #75 for the Enable/`config.get` failure.
+2. Ask reporter to upgrade to ≥ 0.9.0, retry Enable.
+3. If Enable works but reindex returns 500, move that thread to #80 (or a focused follow-up) with Doctor diagnostics + `memory status` output.
+4. Close #76 as fixed/duplicate once Enable succeeds or reporter confirms upgrade.

--- a/docs/issue-audit/drafts/77.md
+++ b/docs/issue-audit/drafts/77.md
@@ -1,0 +1,28 @@
+## Draft reply for #77 — Unable to scroll on tasks page
+
+**Status:** Valid bug. Keep open — likely regressed after the kanban dispatch rewrite.
+
+### Analysis
+
+Reporter: `/tasks` has no scrollbar; wheel does nothing.
+
+Current layout (`src/components/tasks-view.tsx`):
+
+- Board container: `md:overflow-y-hidden`
+- Grid: `items-start` (columns size to content)
+- Column body: `overflow-y-auto` but column itself is not height-bounded (`md:h-full` missing)
+
+Result: columns grow with cards; parent clips overflow; per-column scroll never engages on desktop. Mobile path (`overflow-y-auto`) is healthier.
+
+An earlier fix that bound columns with `md:h-full` is not present on current main after the live-dispatch kanban work.
+
+### Proposed solution
+
+1. Restore a height chain: `SectionLayout` → board → grid row → column → card list all participate in `min-h-0` / `h-full` / `flex-1`.
+2. Keep **per-column** scroll (power-user kanban), not only page scroll — users with many cards in one status need independent scrolling.
+3. Add keyboard / trackpad affordances and ensure drag-and-drop still works while scrolling.
+4. Playwright regression: seed >N cards in one column; assert column scrollHeight > clientHeight and wheel moves scrollTop.
+
+### Close plan
+
+Close only after the layout fix ships and a screenshot/GIF confirms desktop + mobile scroll.

--- a/docs/issue-audit/drafts/78.md
+++ b/docs/issue-audit/drafts/78.md
@@ -1,0 +1,19 @@
+## Draft reply for #78 — Skill detail crash (`Cannot read properties of undefined (reading 'bins')`)
+
+**Status:** Fixed on main (v0.9.0). Candidate to close after upgrade confirmation.
+
+### Analysis
+
+Headless / degraded skill detail payloads omitted `missing` / `requirements`. UI read `detail.missing.bins` and crashed.
+
+On main:
+
+- `normalizeRequirements` always returns arrays (`src/lib/skills-status.ts`)
+- Skills UI uses `requirementBag()` / optional chaining (`src/components/skills-view.tsx`)
+- Detail route prefers RPC inventory and falls back without assuming bags exist
+
+### Close plan
+
+1. Ask reporter to upgrade to ≥ 0.9.0.
+2. Open a skill detail page under systemd/Docker; confirm no React crash and a clear Ready / Needs setup / Unavailable state.
+3. Close as completed. If a specific skill still crashes, reopen with the skill name + network payload from `/api/skills`.

--- a/docs/issue-audit/drafts/80.md
+++ b/docs/issue-audit/drafts/80.md
@@ -1,0 +1,28 @@
+## Draft reply for #80 — Gateway offline while online + vector reindex 500
+
+**Status:** Split issue. Gateway false-offline half fixed; reindex half may still deserve follow-up.
+
+### Analysis
+
+Two symptoms:
+
+1. **Gateway shown offline while actually online** — historically the same false-negative stack as #75 (HTTP exec probe / wrong liveness). Main now probes `GET /health` (`src/lib/gateway-liveness.ts`) and decouples RPC from HTTP exec. Status API maps probe-false to **degraded** rather than hard-offline in several paths.
+2. **Vector DB reindex failed (500)** — separate path: `gatewayMemoryIndex` / `memory index` CLI (`src/lib/gateway-tools.ts`, `/api/vector`). Can 500 when embeddings provider missing, model unloaded, or CLI cold-start fails — even if the gateway process is up.
+
+### Proposed solution
+
+**Gateway half (close with #75):**
+
+- Upgrade ≥ 0.9.0; confirm sidebar/Doctor gateway state matches reality.
+- If still wrong: capture gateway bind URL, Tailscale/proxy, auth mode, `/health` curl, `/api/status` JSON.
+
+**Reindex half (keep or spin out):**
+
+- Prefer gateway memory tools when available; CLI fallback with 60s timeout and structured error body (not bare 500).
+- UI: show *why* reindex failed (no embedding model, Ollama down, missing local plugin) + deep link to Vectors settings / Doctor fix.
+- Preflight: refuse reindex with a clear CTA when provider is not ready.
+
+### Close plan
+
+- Close the gateway-offline claim as fixed after upgrade confirmation (link #75).
+- Leave open *or* open “Vector reindex error UX” if reporter still hits 500 after Enable works.

--- a/docs/issue-audit/drafts/81.md
+++ b/docs/issue-audit/drafts/81.md
@@ -1,0 +1,21 @@
+## Draft reply for #81 — Agent fleet panel not scrollable (mobile)
+
+**Status:** Valid UX bug / power-user gap. Keep open.
+
+### Analysis
+
+Reporter (Mac Mini → iPhone): Agents tab shows a fixed-height panel; agents below the fold are inaccessible; no scroll.
+
+On main, Agents defaults to **Hierarchy / Flow** (`viewMode = "flow"`), rendered in `h-0 flex-1 overflow-hidden` — React Flow canvas uses pan/zoom, not DOM scroll. Grid view scrolls via `SectionBody`, but is not the default and may be hard to discover on mobile.
+
+### Proposed solution (more user power)
+
+1. **Mobile default:** open **Grid** (or a compact Fleet list) below `md`; keep Hierarchy on desktop.
+2. **Hierarchy affordances:** visible “pinch / drag to pan” hint; fit-view on load; mini-map; ensure touch panning works in mobile Safari.
+3. **Fleet list mode:** searchable, filterable list of all agents (status, model, channels) with overflow scroll — best control surface for large fleets.
+4. Persist last view mode in localStorage / URL (`?tab=` already partially exists).
+5. Deep link: `/agents?view=grid` for shareable mobile bookmarks.
+
+### Close plan
+
+Close after mobile can reach every agent without gesture guesswork (grid/list default or working pan + hint), with a short iPhone recording attached to the fix PR.

--- a/docs/issue-audit/drafts/82.md
+++ b/docs/issue-audit/drafts/82.md
@@ -1,0 +1,18 @@
+## Draft reply for #82 — save-and-restart 15s timeout on `config set`
+
+**Status:** Fixed on main. Candidate to close after upgrade confirmation.
+
+### Analysis
+
+On v0.4.0, Step 2 called `openclaw config set agents.defaults.model.primary …` with the default **15s** CLI timeout. Cold OpenClaw CLI (plugin load + doctor) exceeded 15s → `This operation was aborted` even though the API key write succeeded.
+
+On v0.9.0:
+
+- Config writes use `CONFIG_WRITE_TIMEOUT_MS = 60_000` (`src/lib/openclaw.ts`).
+- Onboard `save-and-restart` prefers disk write + `patchConfig` / longer onboard CLI (60s), avoiding a second cold `config set` for primary model (`src/app/api/onboard/route.ts`).
+
+### Close plan
+
+1. Ask reporter to upgrade to ≥ 0.9.0 and re-run model onboarding.
+2. If Abort still appears, capture which step and server logs — treat as a new timeout hotspot, not the original Step 2 path.
+3. Close as completed once confirmed.

--- a/docs/issue-audit/drafts/84.md
+++ b/docs/issue-audit/drafts/84.md
@@ -1,0 +1,28 @@
+## Draft reply for #84 — `/api/pairing` fails: `pairing list` requires `--channel`
+
+**Status:** Fixed on main. Candidate to close after upgrade confirmation.
+
+### Analysis
+
+OpenClaw ≥ ~2026.5.4 requires a channel:
+
+```bash
+openclaw pairing list --channel <channel> [--account <id>] --json
+```
+
+Docs: https://docs.openclaw.ai/channels/pairing
+
+Calling `pairing list` with no channel spammed gateway logs and broke the dashboard poller.
+
+Fixed in `src/app/api/pairing/route.ts`:
+
+1. Discover channels via `channels.status` RPC.
+2. Run `pairing list --channel <ch> [--account] --json` per target.
+3. If no channels configured, skip CLI and fall back to credentials filesystem scan.
+4. Approve uses `pairing approve <channel> <code>`.
+
+### Close plan
+
+1. Ask reporter on v0.5.1 / OpenClaw 2026.5.4 to upgrade Mission Control to ≥ 0.9.0.
+2. Confirm `/api/pairing` returns JSON without gateway stack traces.
+3. Close as completed.

--- a/docs/issue-audit/drafts/85.md
+++ b/docs/issue-audit/drafts/85.md
@@ -1,0 +1,21 @@
+## Draft reply for #85 — Usage not working
+
+**Status:** Same gateway RPC root as #75. Candidate duplicate close after upgrade + retest.
+
+### Analysis
+
+Diagnostics:
+
+- warn: Live gateway sessions are unavailable; live usage may be incomplete.
+- error gateway: `Gateway RPC unavailable for sessions.list — gateway is not reachable via HTTP`
+
+Usage live path calls `sessions.list` (`src/lib/gateway-sessions.ts` → `/api/usage`). That failed under the old HTTP-exec conflation. With RPC healthy, sessions ingest into the local usage ledger; empty charts with those exact diagnostics mean RPC never connected — not a missing Usage feature.
+
+Local-only models (related to #70) may still show $0 / missing pricing — that is expected without provider price tables, and should be labeled “local / unpriced” rather than looking broken.
+
+### Close plan
+
+1. Duplicate of #75 for the HTTP RPC error string.
+2. Upgrade ≥ 0.9.0; reopen Usage; confirm diagnostics clear and sessions appear.
+3. If Usage stays empty *with* a healthy gateway: file a focused follow-up (ledger ingest / session shape), not this issue.
+4. Close as fixed/duplicate after confirmation.

--- a/docs/issue-audit/drafts/86.md
+++ b/docs/issue-audit/drafts/86.md
@@ -1,0 +1,19 @@
+## Draft reply for #86 — Partnership inquiry from MyClaw.ai
+
+**Status:** Not a product defect. Close as off-topic / redirect to private channel. Do not treat as engineering work.
+
+### Analysis
+
+Outbound partnership / hosting collaboration pitch. No repro, no Mission Control bug, no OpenClaw API change requested.
+
+Mission Control’s product stance (README): local-first, data stays on the user’s machine. A managed-hosting partnership may still be interesting commercially, but it is not an issue-tracker item and should not compete with user bugs for attention.
+
+### Close plan
+
+1. Owner replies privately (email / social) if interested — or politely declines.
+2. Close the GitHub issue with a short public note: thanks; partnerships are handled off the issue tracker; please email …
+3. Optional: add a CONTRIBUTING / Support blurb so future partnership spam can be closed the same way.
+
+### Suggested public close comment
+
+> Thanks for reaching out. Partnership and hosting discussions aren’t tracked as GitHub issues — please contact me privately. Closing this so the issue list stays focused on Mission Control bugs and features.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Full audit of all **12 open GitHub issues** against Mission Control `v0.9.0` and current OpenClaw docs. **Nothing was closed on GitHub** — this PR only adds draft analysis and ready-to-post replies.

## Artifacts

- `docs/issue-audit/README.md` — triage table + disposition
- `docs/issue-audit/IMPLEMENTATION.md` — engineering plans for issues that should stay open
- `docs/issue-audit/drafts/{70,73,75,76,77,78,80,81,82,84,85,86}.md` — per-issue draft comments

## Highlights

| Keep / build | Close after upgrade confirm | Non-bug |
|--------------|----------------------------|---------|
| **#70** local-only models (P0 power feature) | **#75/#76/#85** gateway HTTP-vs-RPC false negatives (fixed in #87) | **#86** partnership → private |
| **#77** tasks scroll (likely regressed) | **#78** skill `bins` crash | |
| **#81** agents fleet mobile reachability | **#82** onboard 15s timeout | |
| **#73** residual CLI stderr hardening | **#84** `pairing list --channel` | |
| **#80** split: gateway fixed; reindex UX follow-up | | |

OpenClaw docs used: local models, Ollama, pairing, configuration/`config.get`.

## Next steps (human)

1. Review drafts for tone.
2. Optionally post replies; close fixed cluster only after reporter upgrade confirmation.
3. Prioritize #70 → #77/#81 → residual #73/#80 reindex.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fed42-7210-71a0-9def-3de3b2b6d5ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fed42-7210-71a0-9def-3de3b2b6d5ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

