### PR TITLE
Fix Docker deployment compatibility (OpenClaw 2026.6.9+, update route, sqlite3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ENV NODE_ENV=production
 # does `git pull --ff-only` + `npm ci` + `npm run build` in place, so the runtime image
 # needs git, the full source tree (not just build output), and .git/ itself — not just
 # the .next/public/node_modules subset a normal production image would ship.
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+# sqlite3 (the CLI, not a Node module) is shelled out to by src/lib/usage-db.ts for
+# usage tracking — also absent from the slim base image.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app /app
 # Mission Control shells out to the `openclaw` CLI at runtime (doctor/status/lint/etc),

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Authored locally after auditing this repo (no upstream Dockerfile exists).
+# Standard multi-stage Next.js build; nothing here shells out to the host.
+FROM node:24-bookworm-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --include=optional --no-audit --no-fund
+
+FROM node:24-bookworm-slim AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:24-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+# Mission Control's own in-dashboard "Update" button (src/app/api/mission-control-update)
+# does `git pull --ff-only` + `npm ci` + `npm run build` in place, so the runtime image
+# needs git, the full source tree (not just build output), and .git/ itself — not just
+# the .next/public/node_modules subset a normal production image would ship.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /app /app
+# Mission Control shells out to the `openclaw` CLI at runtime (doctor/status/lint/etc),
+# so the CLI runtime from the official gateway image is bundled in alongside it.
+COPY --from=alpine/openclaw:latest /app /opt/openclaw-cli
+RUN ln -sf /opt/openclaw-cli/openclaw.mjs /usr/local/bin/openclaw && \
+    chown -R node:node /app /opt/openclaw-cli && \
+    git config --system --add safe.directory /app
+ENV OPENCLAW_BIN=/opt/openclaw-cli/openclaw.mjs
+USER node
+EXPOSE 3333
+# Run next directly (not via npx, which spawns it as a child) so this process is
+# PID 1: the update route can process.exit() after a successful rebuild and rely
+# on the container's `restart: unless-stopped` policy to bring the new build up.
+CMD ["node_modules/.bin/next", "start", "-H", "0.0.0.0", "-p", "3333"]

--- a/src/app/api/mission-control-update/route.ts
+++ b/src/app/api/mission-control-update/route.ts
@@ -423,14 +423,22 @@ export async function POST(request: NextRequest) {
     }
 
     const after = await buildStatus(false);
-    return NextResponse.json({
+    const response = NextResponse.json({
       ok: true,
       steps,
       before,
       after,
       restartRequired: true,
-      restartHint: after.restartHint || "Restart Mission Control to apply the updated build.",
+      restarting: true,
+      restartHint:
+        "Rebuilt successfully. Restarting now to apply it — this page will be briefly unreachable, then come back on the new build.",
     });
+    // Exit once the response has had a chance to flush. The container's
+    // `restart: unless-stopped` policy brings the process back up running
+    // the freshly built .next output — an intentional restart (exit 0), not
+    // a crash; there is no in-flight state left to preserve at this point.
+    setTimeout(() => process.exit(0), 300);
+    return response;
   } catch (err) {
     return NextResponse.json(
       {

--- a/src/app/api/openclaw-update/route.ts
+++ b/src/app/api/openclaw-update/route.ts
@@ -1,5 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
+import { access } from "fs/promises";
 import { CONFIG_WRITE_TIMEOUT_MS, runCli, runCliJson } from "@/lib/openclaw";
+
+/**
+ * `openclaw update` patches its own installed files in place, which cannot
+ * persist in a container (the writable layer resets on recreate) and often
+ * can't even run (root-owned global install dir, non-root container user).
+ * Detected once per process — /.dockerenv is a standard container marker.
+ */
+let _inContainer: boolean | null = null;
+async function isRunningInContainer(): Promise<boolean> {
+  if (_inContainer !== null) return _inContainer;
+  try {
+    await access("/.dockerenv");
+    _inContainer = true;
+  } catch {
+    _inContainer = false;
+  }
+  return _inContainer;
+}
 
 const GITHUB_RELEASES_URL =
   "https://api.github.com/repos/openclaw/openclaw/releases/latest";
@@ -56,6 +75,19 @@ type UpdateRunJson = {
   targetVersion?: string | null;
   actions?: string[];
   notes?: string[];
+  // `openclaw update --json` reports failures (e.g. a permission error mid-step)
+  // as a 0-exit-looking JSON body with status: "error" rather than a thrown
+  // error — runCliJson's JSON-recovery fallback also resurfaces these on a
+  // non-zero exit, so this shape must be checked explicitly, not just `ok`.
+  status?: "ok" | "error" | string;
+  reason?: string;
+  steps?: Array<{
+    name?: string;
+    command?: string;
+    exitCode?: number | null;
+    stderrTail?: string | null;
+    stdoutTail?: string | null;
+  }>;
 };
 
 /**
@@ -165,6 +197,22 @@ export async function POST(request: NextRequest) {
     if (noRestart) args.push("--no-restart");
 
     const result = await runCliJson<UpdateRunJson>(args, 1_260_000);
+
+    if (result?.status === "error") {
+      const failedStep = result.steps?.find((s) => s.exitCode && s.exitCode !== 0);
+      const detail = failedStep?.stderrTail?.trim() || result.reason || "Unknown failure.";
+      const dockerHint = (await isRunningInContainer())
+        ? " This gateway runs in Docker, where self-update can't work: the CLI would be patching files in the container's throwaway layer, which resets on the next restart even if the write succeeded. Update by pulling a new image instead: `docker compose pull openclaw && docker compose up -d --force-recreate openclaw`."
+        : "";
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `Update failed (${result.reason || "unknown step"}): ${detail}${dockerHint}`,
+          result,
+        },
+        { status: 409 },
+      );
+    }
 
     let versionAfter: string | null = null;
     try {

--- a/src/lib/doctor-lint.ts
+++ b/src/lib/doctor-lint.ts
@@ -2,12 +2,13 @@
  * The structured half of the Doctor: `openclaw doctor --lint --json`.
  *
  * This is the only doctor surface that is both read-only and machine-readable.
- * Two flags are load-bearing and must not be dropped:
  *
- * - `--all` — 27 of the 51 registered checks are opt-in. Without it,
- *   `configured-plugin-installs` never runs, and that check has a live warning
- *   on this machine. Measured cost of `--all`: ~4.5–6.7s, versus ~4.0s without.
- *   Half a second is not worth 27 checks.
+ * - `--all` is NOT passed. On OpenClaw 2026.6.9+ it is not a recognized flag —
+ *   the opt-in/opt-out check split it used to control is gone, and `--lint`
+ *   now always runs the full inventory (verified: checksSkipped: 0). Passing
+ *   `--all` anyway makes the CLI exit 2 before it lints anything, which is
+ *   strictly worse than omitting it. If a future CLI reintroduces a check
+ *   subset by default, re-add it then.
  * - `--severity-min info` — the default threshold is `warning`, which silently
  *   discards every info finding. A page that claims to show everything cannot
  *   run with a filter it did not choose.
@@ -65,7 +66,7 @@ export type LintResult = {
   groups: LintGroup[];
 };
 
-export const LINT_ARGS = ["doctor", "--lint", "--all", "--severity-min", "info", "--json"];
+export const LINT_ARGS = ["doctor", "--lint", "--severity-min", "info", "--json"];
 
 const SEVERITY_RANK = { error: 0, warning: 1, info: 2 } as const;
 

--- a/src/lib/doctor-report.ts
+++ b/src/lib/doctor-report.ts
@@ -21,12 +21,13 @@
  * least one finding, `2` = the command failed before it could lint. So a
  * non-zero exit is *not* an error — only exit 2 (or unparseable stdout) is.
  *
- * There is no `--fast` / `--quick` flag on this build. What exists is check
- * *selection*: the default lint set skips checks that are "deep, historical, or
- * more likely to surface repairable legacy residue" (24 run / 27 skipped here),
- * and `--all` runs the complete inventory (51 checks). `fast: true` (the
- * default) therefore means the default set; `fast: false` adds `--all`.
- * Measured on this machine: default ~4.0s warm / ~9.3s cold, `--all` ~4.7s.
+ * There is no `--fast` / `--quick` flag on this build, and as of OpenClaw
+ * 2026.6.9+ there is no `--all` either — the opt-in check split it used to
+ * toggle is gone, and `--lint` always runs the full inventory now (verified:
+ * checksSkipped: 0). Passing `--all` makes the CLI exit 2 before it lints
+ * anything, so it is not sent. `fast` is kept as a parameter name for callers,
+ * but no longer changes which checks run — only kept in case a future CLI
+ * reintroduces a subset.
  *
  * ## Fallback ladder
  *
@@ -666,7 +667,6 @@ export async function runDoctorReport(options: DoctorReportOptions = {}): Promis
   }
 
   const args = ["doctor", "--lint", "--json", "--non-interactive"];
-  if (!fast) args.push("--all");
 
   let result: SpawnResult;
   try {


### PR DESCRIPTION
## Summary
- `doctor --lint --all` was removed as a recognized flag by OpenClaw 2026.6.9+ (the opt-in/opt-out check split it controlled is gone — `--lint` now always runs the full inventory). Passing it made the CLI exit 2 before linting anything, so it's dropped from `LINT_ARGS` and the doctor report args.
- `openclaw-update` route now explicitly checks for `status: "error"` in the CLI's JSON response — previously the failure-recovery JSON parser masked update failures as successes. Also detects when running in Docker and points at `docker compose pull` instead of self-update, which can't persist in a container's writable layer.
- `mission-control-update` route's self-rebuild (`git pull` + `npm ci` + `npm run build`) now passes `--include=dev` — under `NODE_ENV=production`, `npm ci` was silently omitting devDependencies (including `typescript`, which `next.config.ts` needs to build), so the in-place rebuild failed. It also `process.exit(0)`s after a successful rebuild so the container's `restart: unless-stopped` policy brings the new build up automatically.
- Added a multi-stage `Dockerfile` (none existed upstream): runtime image ships git + full source tree + `.git/` so the in-dashboard update route can actually run its git pull/build cycle, bundles the `openclaw` CLI from the official gateway image since Mission Control shells out to it at runtime, and installs the `sqlite3` CLI (shelled out to by `src/lib/usage-db.ts` for usage tracking, absent from the slim base image).

## Test plan
- [x] Built the image and ran the full stack via `docker-compose.yml` (openclaw + mission-control, sharing the openclaw container's network namespace)
- [x] Verified `openclaw doctor --lint` runs and reports findings (previously exited 2 immediately)
- [x] Verified `sqlite3` CLI is present in the running container and usage tracking has no errors in logs
- [x] Confirmed both containers report healthy and the dashboard serves `200` on :3333

🤖 Generated with [Claude Code](https://claude.com/claude-code)