### PR TITLE
fix: 17 Mission Control bugs — input validation, HTTP status codes, dedupe (bughunt 2026-08-16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ next-env.d.ts
 
 # Private design docs — not for the public repo
 docs/design/
+
+# sqlite backup snapshots
+*.db.bak*

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@
 .DS_Store
 *.pem
 
+# runtime sqlite stores
+interactions.db
+usage.db
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1218,6 +1218,14 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     console.error("Agents API POST error:", err);
     const msg = String(err);
+    // Bug fix 2026-08-16: a malformed JSON body throws a SyntaxError from
+    // `request.json()`. That is a client error, not an internal failure.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     // Make gateway errors user-friendly
     if (msg.includes("already exists") || msg.includes("Agent already")) {
       return NextResponse.json(

--- a/src/app/api/audio/route.ts
+++ b/src/app/api/audio/route.ts
@@ -873,6 +873,14 @@ export async function POST(request: NextRequest) {
     }
   } catch (err) {
     console.error("Audio API POST error:", err);
+    // Bug fix 2026-08-16: a malformed/empty JSON body throws a SyntaxError from
+    // `request.json()`. That is a client error, not an internal failure.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: String(err) }, { status: 500 });
   }
 }

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -34,6 +34,13 @@ export async function GET(request: NextRequest) {
       headers: { "Cache-Control": "no-store" },
     });
   } catch (error) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${error.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : String(error) },
       { status: 500 }
@@ -127,6 +134,13 @@ export async function POST(request: NextRequest) {
         );
     }
   } catch (error) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${error.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : String(error) },
       { status: 500 }

--- a/src/app/api/heartbeat/route.ts
+++ b/src/app/api/heartbeat/route.ts
@@ -467,6 +467,13 @@ export async function POST(request: NextRequest) {
     );
   } catch (err) {
     console.error("Heartbeat POST error:", err);
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (err instanceof SyntaxError) {
+      return jsonNoStore(
+        { ok: false, error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return jsonNoStore({ ok: false, error: String(err) }, { status: 500 });
   }
 }

--- a/src/app/api/interactions/intake/route.ts
+++ b/src/app/api/interactions/intake/route.ts
@@ -71,15 +71,31 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true, interaction });
     }
     if (!body.interaction) return NextResponse.json({ error: "interaction is required" }, { status: 400 });
+    // Bug fix 2026-08-16: validate `source` before delegating. Without it, the
+    // awareness engine throws "Cannot read properties of undefined (reading
+    // 'runId')" and surfaces as a generic 500. Surface a precise 400 instead.
+    if (!body.interaction.source || typeof body.interaction.source !== "object") {
+      return NextResponse.json(
+        { error: "interaction.source is required (kind, id, label, and optional sessionKey/agentId)" },
+        { status: 400 },
+      );
+    }
     // Overwrite any caller-supplied tenant/user with the server-resolved scope.
     const interaction = await requestClarification({
       ...body.interaction,
       tenantId: scope.tenantId,
       userId: scope.userId,
+      runId: body.runId,
     });
     return NextResponse.json({ ok: true, interaction }, { status: 201 });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return NextResponse.json({ error: message }, { status: /required|characters/i.test(message) ? 400 : 500 });
+    // Bug fix 2026-08-16: extend the client-error heuristic so the new
+    // `validateQuestion` messages (type checks, NUL-byte checks) surface as
+    // 400 instead of 500. Matches: "required", "characters", "must be a string",
+    // "must not contain", "must start with", "must contain only".
+    const isClientError =
+      /required|characters|must be a string|must not contain|must start with|must contain only/i.test(message);
+    return NextResponse.json({ error: message }, { status: isClientError ? 400 : 500 });
   }
 }

--- a/src/app/api/permissions/route.ts
+++ b/src/app/api/permissions/route.ts
@@ -507,6 +507,14 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
   } catch (err) {
+    // Bug fix 2026-08-16: a malformed JSON body throws a SyntaxError from
+    // `request.json()`. That is a client error, not an internal failure.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: cliError(err) }, { status: 500 });
   }
 }

--- a/src/app/api/security/route.ts
+++ b/src/app/api/security/route.ts
@@ -315,6 +315,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
   } catch (err) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { ok: false, error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: cliError(err) }, { status: 500 });
   }
 }

--- a/src/app/api/skills/test/route.ts
+++ b/src/app/api/skills/test/route.ts
@@ -84,6 +84,13 @@ export async function POST(request: NextRequest) {
       durationMs: Date.now() - startedAt,
     });
   } catch (err) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { ok: false, error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json(
       { ok: false, error: message || "Skill test failed" },

--- a/src/app/api/tailscale/route.ts
+++ b/src/app/api/tailscale/route.ts
@@ -59,11 +59,28 @@ function parseUrlsFromStatusText(text: string): string[] {
     .map((line) => line.split(" ")[0]);
 }
 
+/**
+ * Typed error thrown when the `tailscale` binary is not on PATH. Distinguishes
+ * "feature unavailable on this host" from generic subprocess failures, so route
+ * handlers can return 503 (Service Unavailable) instead of a generic 500.
+ *
+ * The class lives in src/lib/tailscale.ts (not here) because Next.js typed
+ * routes reject any non-handler export from route files.
+ */
+import { TailscaleNotInstalledError } from "@/lib/tailscale";
+
 async function runTailscale(args: string[], timeout = 12000): Promise<{ stdout: string; stderr: string }> {
-  return exec("tailscale", args, {
-    timeout,
-    env: { ...process.env, NO_COLOR: "1" },
-  });
+  try {
+    return await exec("tailscale", args, {
+      timeout,
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && (err as { code?: string }).code === "ENOENT") {
+      throw new TailscaleNotInstalledError();
+    }
+    throw err;
+  }
 }
 
 function normalizeRunArgs(value: unknown): string[] {
@@ -225,6 +242,9 @@ export async function POST(req: Request) {
         output: normalizeCliText(out.stdout, out.stderr),
       });
     } catch (err) {
+      // Bug fix 2026-08-16: distinguish "tailscale not installed" (503) from
+      // other subprocess failures (500).
+      const status = err instanceof TailscaleNotInstalledError ? 503 : 500;
       return NextResponse.json(
         {
           ok: false,
@@ -232,13 +252,14 @@ export async function POST(req: Request) {
           args,
           error: formatExecError(err),
         },
-        { status: 500 }
+        { status }
       );
     }
   } catch (err) {
+    const status = err instanceof TailscaleNotInstalledError ? 503 : 500;
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : String(err) },
-      { status: 500 }
+      { status }
     );
   }
 }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -68,6 +68,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: true, ...(await getTasksSnapshot(scope)) });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // Bug fix 2026-08-16: the OpenClaw CLI surfaces "Task not found" / "TaskFlow
+    // not found" with a non-zero exit code. Map these to 404 instead of a generic
+    // 500 so clients can distinguish "doesn't exist" from "internal failure".
+    if (/Task(?:Flow)? not found/i.test(message)) {
+      return NextResponse.json({ ok: false, error: message }, { status: 404 });
+    }
     const status = /required|must be/i.test(message) ? 400 : 500;
     return NextResponse.json({ ok: false, error: message }, { status });
   }

--- a/src/lib/awareness/engine.ts
+++ b/src/lib/awareness/engine.ts
@@ -10,12 +10,16 @@ import {
 import type { CreateInteractionInput, InteractionRequest, InteractionResolution } from "./types";
 
 export async function requestClarification(
-  input: Omit<CreateInteractionInput, "idempotencyKey"> & { idempotencyKey?: string },
+  input: Omit<CreateInteractionInput, "idempotencyKey"> & { idempotencyKey?: string; runId?: string },
 ) {
+  // Allow explicit caller-provided idempotencyKey OR a caller-provided runId to
+  // scope the key. Falls back to source-derived key only when neither is given.
+  // Bug fix 2026-08-16: body.runId was previously ignored, causing silent dedup
+  // for retried runs with identical source+question combinations.
+  const explicitKey = input.idempotencyKey || (input.runId ? `run:${input.runId}` : undefined);
   return createInteraction({
     ...input,
-    idempotencyKey:
-      input.idempotencyKey || buildInteractionIdempotencyKey(input.source, input.question),
+    idempotencyKey: explicitKey || buildInteractionIdempotencyKey(input.source, input.question),
   });
 }
 

--- a/src/lib/awareness/protocol.ts
+++ b/src/lib/awareness/protocol.ts
@@ -107,14 +107,28 @@ export function validateQuestion(input: {
   choices?: InteractionChoice[];
 }): string[] {
   const errors: string[] = [];
-  const question = input.question.trim();
-  if (!input.title.trim()) errors.push("title is required");
+  // Bug fix 2026-08-16: callers previously sent non-string values (numbers,
+  // arrays) or strings containing NUL bytes. `.trim()` blew up with
+  // "a.title.trim is not a function" or "a.question.trim is not a function",
+  // and NUL bytes made it to `sqlite3` which threw "must be a string without
+  // null bytes". Reject those inputs up front with a clear 400-style error.
+  if (typeof input.title !== "string") errors.push("title must be a string");
+  if (typeof input.question !== "string") errors.push("question must be a string");
+  if (typeof input.title === "string" && input.title.includes("\u0000")) {
+    errors.push("title must not contain NUL bytes");
+  }
+  if (typeof input.question === "string" && input.question.includes("\u0000")) {
+    errors.push("question must not contain NUL bytes");
+  }
+  const question = typeof input.question === "string" ? input.question.trim() : "";
+  if (typeof input.title === "string" && !input.title.trim()) errors.push("title is required");
   if (!question) errors.push("question is required");
   if (question.length > 2000) errors.push("question must be 2000 characters or fewer");
-  if (input.title.trim().length > 240) errors.push("title must be 240 characters or fewer");
+  if (typeof input.title === "string" && input.title.trim().length > 240) errors.push("title must be 240 characters or fewer");
   const ids = new Set<string>();
   for (const choice of input.choices || []) {
-    if (!choice.id.trim() || !choice.label.trim() || !choice.value.trim()) {
+    if (typeof choice.id !== "string" || typeof choice.label !== "string" || typeof choice.value !== "string" ||
+        !choice.id.trim() || !choice.label.trim() || !choice.value.trim()) {
       errors.push("every choice requires id, label, and value");
       continue;
     }

--- a/src/lib/tailscale.ts
+++ b/src/lib/tailscale.ts
@@ -1,0 +1,23 @@
+/**
+ * Tailscale helpers — error class shared between the tailscale route and any
+ * future caller that wants to detect "tailscale binary missing on this host".
+ *
+ * Defined here (not in route.ts) so route modules stay clean of non-handler
+ * exports; Next.js' typed-routes system rejects extra exports on route files.
+ */
+
+/**
+ * Thrown by `runTailscale` (and any caller) when the `tailscale` binary is not on
+ * PATH. Distinguishes "feature unavailable on this host" from generic subprocess
+ * failures, so route handlers can return 503 (Service Unavailable) instead of a
+ * generic 500.
+ *
+ * Bug fix 2026-08-16: previously ENOENT bubbled up as "spawn tailscale ENOENT"
+ * with status 500, hiding the real cause from the UI.
+ */
+export class TailscaleNotInstalledError extends Error {
+  constructor() {
+    super("tailscale CLI not installed on this host");
+    this.name = "TailscaleNotInstalledError";
+  }
+}


### PR DESCRIPTION
17 fixes from a bughunt session: input validation → 400, correct HTTP status codes (404/503/400), 
and idempotency dedup. No breaking changes; error handling improvements only.

## Fixes

**400 instead of 500 on malformed JSON body:**
- `src/app/api/agents/route.ts` — catch SyntaxError from request.json()
- `src/app/api/permissions/route.ts` — same pattern
- `src/app/api/audio/route.ts` — same pattern
- `src/app/api/skills/test/route.ts` — same pattern
- `src/app/api/security/route.ts` — same pattern
- `src/app/api/calendar/route.ts` — both GET and POST
- `src/app/api/heartbeat/route.ts` — same pattern

**Improved validation:**
- `src/app/api/interactions/intake/route.ts` — validate `interaction.source` before 
  delegating (previously threw "Cannot read properties of undefined")
- `src/lib/awareness/protocol.ts` — type guards + NUL-byte check in `validateQuestion`, 
  and broadened client-error regex to catch new validation messages

**Correct status codes:**
- `src/app/api/tasks/route.ts` — 404 on cancel/cancel-flow for unknown task id
- `src/app/api/tailscale/route.ts` + `src/lib/tailscale.ts` — new 
  `TailscaleNotInstalledError` class distinguishes "binary not on PATH" (503) 
  from generic subprocess failures (500)

**Dedup fix:**
- `src/lib/awareness/engine.ts` — `runId` was previously ignored when building the 
  idempotency key, causing silent dedup of distinct retried runs

**Chore:**
- `.gitignore` — ignore runtime sqlite stores (interactions.db, usage.db) and 
  backup snapshots (*.db.bak*)
