### PR TITLE
fix: 4 Mission Control arch fixes — 501 usage, SSE leak, interactions/[id], tasks 413/E2BIG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ next-env.d.ts
 
 # Private design docs — not for the public repo
 docs/design/
+
+# sqlite backup snapshots
+*.db.bak*

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@
 .DS_Store
 *.pem
 
+# runtime sqlite stores
+interactions.db
+usage.db
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1218,6 +1218,14 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     console.error("Agents API POST error:", err);
     const msg = String(err);
+    // Bug fix 2026-08-16: a malformed JSON body throws a SyntaxError from
+    // `request.json()`. That is a client error, not an internal failure.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     // Make gateway errors user-friendly
     if (msg.includes("already exists") || msg.includes("Agent already")) {
       return NextResponse.json(

--- a/src/app/api/audio/route.ts
+++ b/src/app/api/audio/route.ts
@@ -873,6 +873,14 @@ export async function POST(request: NextRequest) {
     }
   } catch (err) {
     console.error("Audio API POST error:", err);
+    // Bug fix 2026-08-16: a malformed/empty JSON body throws a SyntaxError from
+    // `request.json()`. That is a client error, not an internal failure.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: String(err) }, { status: 500 });
   }
 }

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -34,6 +34,13 @@ export async function GET(request: NextRequest) {
       headers: { "Cache-Control": "no-store" },
     });
   } catch (error) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${error.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : String(error) },
       { status: 500 }
@@ -127,6 +134,13 @@ export async function POST(request: NextRequest) {
         );
     }
   } catch (error) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${error.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : String(error) },
       { status: 500 }

--- a/src/app/api/heartbeat/route.ts
+++ b/src/app/api/heartbeat/route.ts
@@ -467,6 +467,13 @@ export async function POST(request: NextRequest) {
     );
   } catch (err) {
     console.error("Heartbeat POST error:", err);
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (err instanceof SyntaxError) {
+      return jsonNoStore(
+        { ok: false, error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return jsonNoStore({ ok: false, error: String(err) }, { status: 500 });
   }
 }

--- a/src/app/api/interactions/[id]/route.ts
+++ b/src/app/api/interactions/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolveInteractionScope } from "@/lib/awareness/scope";
+import { getInteraction } from "@/lib/awareness/store";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const normalized = id.trim();
+    if (!normalized) {
+      return NextResponse.json({ error: "Interaction id is required" }, { status: 400 });
+    }
+    const scope = resolveInteractionScope(request);
+    const interaction = await getInteraction(normalized, scope.tenantId);
+    if (!interaction) {
+      return NextResponse.json({ error: "Interaction not found" }, { status: 404 });
+    }
+    return NextResponse.json({ interaction });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/interactions/intake/route.ts
+++ b/src/app/api/interactions/intake/route.ts
@@ -71,15 +71,31 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true, interaction });
     }
     if (!body.interaction) return NextResponse.json({ error: "interaction is required" }, { status: 400 });
+    // Bug fix 2026-08-16: validate `source` before delegating. Without it, the
+    // awareness engine throws "Cannot read properties of undefined (reading
+    // 'runId')" and surfaces as a generic 500. Surface a precise 400 instead.
+    if (!body.interaction.source || typeof body.interaction.source !== "object") {
+      return NextResponse.json(
+        { error: "interaction.source is required (kind, id, label, and optional sessionKey/agentId)" },
+        { status: 400 },
+      );
+    }
     // Overwrite any caller-supplied tenant/user with the server-resolved scope.
     const interaction = await requestClarification({
       ...body.interaction,
       tenantId: scope.tenantId,
       userId: scope.userId,
+      runId: body.runId,
     });
     return NextResponse.json({ ok: true, interaction }, { status: 201 });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return NextResponse.json({ error: message }, { status: /required|characters/i.test(message) ? 400 : 500 });
+    // Bug fix 2026-08-16: extend the client-error heuristic so the new
+    // `validateQuestion` messages (type checks, NUL-byte checks) surface as
+    // 400 instead of 500. Matches: "required", "characters", "must be a string",
+    // "must not contain", "must start with", "must contain only".
+    const isClientError =
+      /required|characters|must be a string|must not contain|must start with|must contain only/i.test(message);
+    return NextResponse.json({ error: message }, { status: isClientError ? 400 : 500 });
   }
 }

--- a/src/app/api/permissions/route.ts
+++ b/src/app/api/permissions/route.ts
@@ -507,6 +507,14 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
   } catch (err) {
+    // Bug fix 2026-08-16: a malformed JSON body throws a SyntaxError from
+    // `request.json()`. That is a client error, not an internal failure.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: cliError(err) }, { status: 500 });
   }
 }

--- a/src/app/api/security/route.ts
+++ b/src/app/api/security/route.ts
@@ -315,6 +315,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
   } catch (err) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { ok: false, error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: cliError(err) }, { status: 500 });
   }
 }

--- a/src/app/api/skills/test/route.ts
+++ b/src/app/api/skills/test/route.ts
@@ -84,6 +84,13 @@ export async function POST(request: NextRequest) {
       durationMs: Date.now() - startedAt,
     });
   } catch (err) {
+    // Bug fix 2026-08-16: malformed JSON body throws SyntaxError from `request.json()`.
+    if (err instanceof SyntaxError) {
+      return NextResponse.json(
+        { ok: false, error: `Invalid JSON body: ${err.message}` },
+        { status: 400 },
+      );
+    }
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json(
       { ok: false, error: message || "Skill test failed" },

--- a/src/app/api/stats/stream/route.ts
+++ b/src/app/api/stats/stream/route.ts
@@ -517,6 +517,7 @@ export async function GET() {
 
   const encoder = new TextEncoder();
   let closed = false;
+  let interval: ReturnType<typeof setInterval> | undefined;
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -538,7 +539,7 @@ export async function GET() {
       }
 
       // Then send updates every 5 seconds
-      const interval = setInterval(async () => {
+      interval = setInterval(async () => {
         if (closed) {
           clearInterval(interval);
           return;
@@ -557,6 +558,7 @@ export async function GET() {
     },
     cancel() {
       closed = true;
+      if (interval) clearInterval(interval);
     },
   });
 

--- a/src/app/api/tailscale/route.ts
+++ b/src/app/api/tailscale/route.ts
@@ -59,11 +59,28 @@ function parseUrlsFromStatusText(text: string): string[] {
     .map((line) => line.split(" ")[0]);
 }
 
+/**
+ * Typed error thrown when the `tailscale` binary is not on PATH. Distinguishes
+ * "feature unavailable on this host" from generic subprocess failures, so route
+ * handlers can return 503 (Service Unavailable) instead of a generic 500.
+ *
+ * The class lives in src/lib/tailscale.ts (not here) because Next.js typed
+ * routes reject any non-handler export from route files.
+ */
+import { TailscaleNotInstalledError } from "@/lib/tailscale";
+
 async function runTailscale(args: string[], timeout = 12000): Promise<{ stdout: string; stderr: string }> {
-  return exec("tailscale", args, {
-    timeout,
-    env: { ...process.env, NO_COLOR: "1" },
-  });
+  try {
+    return await exec("tailscale", args, {
+      timeout,
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && (err as { code?: string }).code === "ENOENT") {
+      throw new TailscaleNotInstalledError();
+    }
+    throw err;
+  }
 }
 
 function normalizeRunArgs(value: unknown): string[] {
@@ -225,6 +242,9 @@ export async function POST(req: Request) {
         output: normalizeCliText(out.stdout, out.stderr),
       });
     } catch (err) {
+      // Bug fix 2026-08-16: distinguish "tailscale not installed" (503) from
+      // other subprocess failures (500).
+      const status = err instanceof TailscaleNotInstalledError ? 503 : 500;
       return NextResponse.json(
         {
           ok: false,
@@ -232,13 +252,14 @@ export async function POST(req: Request) {
           args,
           error: formatExecError(err),
         },
-        { status: 500 }
+        { status }
       );
     }
   } catch (err) {
+    const status = err instanceof TailscaleNotInstalledError ? 503 : 500;
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : String(err) },
-      { status: 500 }
+      { status }
     );
   }
 }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -8,8 +8,23 @@ import {
   setNotify,
   showTask,
 } from "@/lib/tasks-native";
+import { readJsonBody } from "@/lib/http";
 
 export const dynamic = "force-dynamic";
+
+/** Max accepted JSON body for POST /api/tasks (action/id/policy only). */
+const MAX_TASKS_BODY_BYTES = 1024 * 1024; // 1 MB
+
+/** Max length for a task / flow id passed to the CLI (a UUID/hash is ~36 chars). */
+const MAX_TASK_ID_LENGTH = 512;
+
+/** Validates a task/flow id before it reaches the OpenClaw CLI subprocess. */
+function validateTaskId(id: unknown): string | null {
+  const raw = typeof id === "string" ? id.trim() : "";
+  if (!raw) return "Invalid id";
+  if (raw.length > MAX_TASK_ID_LENGTH) return "Invalid id";
+  return null;
+}
 
 /**
  * GET /api/tasks?scope=active|all  — the native OpenClaw task + TaskFlow ledger.
@@ -44,20 +59,23 @@ export async function GET(request: NextRequest) {
 
 /** POST — cancel a task/flow, or set a task's notify policy. */
 export async function POST(request: NextRequest) {
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody(request, { maxBytes: MAX_TASKS_BODY_BYTES });
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
   const action = String(body.action || "");
   try {
     if (action === "cancel") {
-      await cancelTask(String(body.id || ""));
+      const idErr = validateTaskId(body.id);
+      if (idErr) return NextResponse.json({ error: idErr }, { status: 400 });
+      await cancelTask(String(body.id));
     } else if (action === "cancel-flow") {
-      await cancelFlow(String(body.id || ""));
+      const idErr = validateTaskId(body.id);
+      if (idErr) return NextResponse.json({ error: idErr }, { status: 400 });
+      await cancelFlow(String(body.id));
     } else if (action === "notify") {
-      await setNotify(String(body.id || ""), String(body.policy || ""));
+      const idErr = validateTaskId(body.id);
+      if (idErr) return NextResponse.json({ error: idErr }, { status: 400 });
+      await setNotify(String(body.id), String(body.policy || ""));
     } else if (action === "maintenance-apply") {
       const result = await runMaintenance(true);
       return NextResponse.json({ ok: true, maintenance: result });

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -68,6 +68,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: true, ...(await getTasksSnapshot(scope)) });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // Bug fix 2026-08-16: the OpenClaw CLI surfaces "Task not found" / "TaskFlow
+    // not found" with a non-zero exit code. Map these to 404 instead of a generic
+    // 500 so clients can distinguish "doesn't exist" from "internal failure".
+    if (/Task(?:Flow)? not found/i.test(message)) {
+      return NextResponse.json({ ok: false, error: message }, { status: 404 });
+    }
     const status = /required|must be/i.test(message) ? 400 : 500;
     return NextResponse.json({ ok: false, error: message }, { status });
   }

--- a/src/app/api/usage/providers/[provider]/route.ts
+++ b/src/app/api/usage/providers/[provider]/route.ts
@@ -14,7 +14,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const supportedProviders = ["openrouter", "openai", "anthropic"] as const;
     type SupportedProvider = (typeof supportedProviders)[number];
     if (!supportedProviders.includes(provider as SupportedProvider)) {
-      return NextResponse.json({ ok: false, error: "Unsupported provider" }, { status: 404 });
+      return NextResponse.json(
+        { ok: false, error: `${provider} usage tracking not yet supported` },
+        { status: 501 },
+      );
     }
     if (request.nextUrl.searchParams.get("refresh") === "1") {
       await maybeCollectProvider(provider as SupportedProvider);
@@ -46,7 +49,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
     const supportedProviders = ["openrouter", "openai", "anthropic"] as const;
     type SupportedProvider = (typeof supportedProviders)[number];
     if (!supportedProviders.includes(provider as SupportedProvider)) {
-      return NextResponse.json({ ok: false, error: "Unsupported provider" }, { status: 404 });
+      return NextResponse.json(
+        { ok: false, error: `${provider} usage tracking not yet supported` },
+        { status: 501 },
+      );
     }
 
     const body = await request.json();

--- a/src/lib/awareness/engine.ts
+++ b/src/lib/awareness/engine.ts
@@ -10,12 +10,16 @@ import {
 import type { CreateInteractionInput, InteractionRequest, InteractionResolution } from "./types";
 
 export async function requestClarification(
-  input: Omit<CreateInteractionInput, "idempotencyKey"> & { idempotencyKey?: string },
+  input: Omit<CreateInteractionInput, "idempotencyKey"> & { idempotencyKey?: string; runId?: string },
 ) {
+  // Allow explicit caller-provided idempotencyKey OR a caller-provided runId to
+  // scope the key. Falls back to source-derived key only when neither is given.
+  // Bug fix 2026-08-16: body.runId was previously ignored, causing silent dedup
+  // for retried runs with identical source+question combinations.
+  const explicitKey = input.idempotencyKey || (input.runId ? `run:${input.runId}` : undefined);
   return createInteraction({
     ...input,
-    idempotencyKey:
-      input.idempotencyKey || buildInteractionIdempotencyKey(input.source, input.question),
+    idempotencyKey: explicitKey || buildInteractionIdempotencyKey(input.source, input.question),
   });
 }
 

--- a/src/lib/awareness/protocol.ts
+++ b/src/lib/awareness/protocol.ts
@@ -107,14 +107,28 @@ export function validateQuestion(input: {
   choices?: InteractionChoice[];
 }): string[] {
   const errors: string[] = [];
-  const question = input.question.trim();
-  if (!input.title.trim()) errors.push("title is required");
+  // Bug fix 2026-08-16: callers previously sent non-string values (numbers,
+  // arrays) or strings containing NUL bytes. `.trim()` blew up with
+  // "a.title.trim is not a function" or "a.question.trim is not a function",
+  // and NUL bytes made it to `sqlite3` which threw "must be a string without
+  // null bytes". Reject those inputs up front with a clear 400-style error.
+  if (typeof input.title !== "string") errors.push("title must be a string");
+  if (typeof input.question !== "string") errors.push("question must be a string");
+  if (typeof input.title === "string" && input.title.includes("\u0000")) {
+    errors.push("title must not contain NUL bytes");
+  }
+  if (typeof input.question === "string" && input.question.includes("\u0000")) {
+    errors.push("question must not contain NUL bytes");
+  }
+  const question = typeof input.question === "string" ? input.question.trim() : "";
+  if (typeof input.title === "string" && !input.title.trim()) errors.push("title is required");
   if (!question) errors.push("question is required");
   if (question.length > 2000) errors.push("question must be 2000 characters or fewer");
-  if (input.title.trim().length > 240) errors.push("title must be 240 characters or fewer");
+  if (typeof input.title === "string" && input.title.trim().length > 240) errors.push("title must be 240 characters or fewer");
   const ids = new Set<string>();
   for (const choice of input.choices || []) {
-    if (!choice.id.trim() || !choice.label.trim() || !choice.value.trim()) {
+    if (typeof choice.id !== "string" || typeof choice.label !== "string" || typeof choice.value !== "string" ||
+        !choice.id.trim() || !choice.label.trim() || !choice.value.trim()) {
       errors.push("every choice requires id, label, and value");
       continue;
     }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Parse a JSON request body with a size guard.
+ *
+ * Two-layer defense against oversized payloads:
+ *  1. Cheap fast-reject on the Content-Length header (when present).
+ *  2. Fallback on the actual byte length after reading the body, so a
+ *     client that omits or lies about Content-Length (e.g. chunked
+ *     transfer-encoding) still cannot exceed `maxBytes`.
+ *
+ * Returns either a parsed body (`ok: true`) or a ready-to-send error
+ * response (`ok: false`). Callers should `return result.response`
+ * directly in the `ok: false` case.
+ */
+export async function readJsonBody(
+  request: Request,
+  { maxBytes }: { maxBytes: number },
+): Promise<{ ok: true; body: Record<string, unknown> } | { ok: false; response: Response }> {
+  const contentLengthRaw = request.headers.get("content-length");
+  if (contentLengthRaw) {
+    const contentLength = Number.parseInt(contentLengthRaw, 10);
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "Payload too large" }, { status: 413 }),
+      };
+    }
+  }
+
+  let raw: string;
+  try {
+    raw = await request.text();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+
+  // Fallback: catch cases where Content-Length was absent, chunked, or lied.
+  if (raw.length > maxBytes) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Payload too large" }, { status: 413 }),
+    };
+  }
+
+  try {
+    const body = JSON.parse(raw) as Record<string, unknown>;
+    return { ok: true, body };
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+}

--- a/src/lib/tailscale.ts
+++ b/src/lib/tailscale.ts
@@ -1,0 +1,23 @@
+/**
+ * Tailscale helpers — error class shared between the tailscale route and any
+ * future caller that wants to detect "tailscale binary missing on this host".
+ *
+ * Defined here (not in route.ts) so route modules stay clean of non-handler
+ * exports; Next.js' typed-routes system rejects extra exports on route files.
+ */
+
+/**
+ * Thrown by `runTailscale` (and any caller) when the `tailscale` binary is not on
+ * PATH. Distinguishes "feature unavailable on this host" from generic subprocess
+ * failures, so route handlers can return 503 (Service Unavailable) instead of a
+ * generic 500.
+ *
+ * Bug fix 2026-08-16: previously ENOENT bubbled up as "spawn tailscale ENOENT"
+ * with status 500, hiding the real cause from the UI.
+ */
+export class TailscaleNotInstalledError extends Error {
+  constructor() {
+    super("tailscale CLI not installed on this host");
+    this.name = "TailscaleNotInstalledError";
+  }
+}


### PR DESCRIPTION
## Summary

Four follow-up architecture fixes from the 2026-08-16 bug-hunt session, stacked on top of PR #90. Each fix is live-verified against Mission Control (`:3333`) through the full build → restart → test cycle.

> **Note (stacked diff):** this branch is stacked on top of #90 (`bugfix/2026-08-16-mc-bughunt`). **PR #90 is still open (not yet merged).** This PR's diff therefore also includes the 14 commits from #90. **Recommendation: merge #90 first; then this can be rebased to a clean 4-commit diff on the updated `main`.**

### The 4 fixes

| # | Commit | Fix | Live-verification |
|---|---|---|---|
| #9 | `c60fe3e` | `usage/providers/:p` → **501** "not yet supported" instead of a generic 404 for unimplemented providers (minimax) | `GET /api/usage/providers/minimax` → **501** `"minimax usage tracking not yet supported"` |
| #6 | `2e650b6` | `stats/stream` SSE: `clearInterval()` in `cancel()` — no interval leak after disconnect | SSE `data:` stream runs; interval now explicitly cleared |
| #4 | `d985e69` | New path route `GET /api/interactions/[id]` (200/404/400) | existing id → **200**, missing → **404**, empty → **400** |
| 413+E2BIG | `7cb3232` | `readJsonBody` helper (413 payload too large + 400 malformed) + id-length check (>512 → 400) in `tasks POST` | 1.5MB body → **413**; `{bad` → **400**; 513-char id → **400**; 36-char UUID → passes through (404 from CLI) |

### Details per fix

1. **#9 — 501 usage provider:** only openrouter/openai/anthropic have billing collectors. A `minimax` request previously returned a confusing 404 "Unsupported provider"; now returns 501 with a precise message. No collector added (MiniMax exposes no usable usage API; quota auto-falls-over to DeepInfra at 100%, resets to 0% every 5h).
2. **#6 — SSE leak:** the interval previously only self-cleared on the next tick; now `cancel()` explicitly calls `clearInterval()`.
3. **#4 — interactions/[id]:** add the path variant (was only the query param), reusing `getInteraction()`.
4. **413+E2BIG — tasks POST:** no body-size guard meant an oversized payload could crash the OpenClaw CLI subprocess with `E2BIG`. New `src/lib/http.ts` `readJsonBody()` (Content-Length fast-check + fallback on actual byte length) + id-length limit (512) before the CLI call.

---

## Out of scope
- **#3 awareness-routes:** intentionally NOT included. This is new functionality (4 new endpoints), not a bug fix — a different review question for an external-contributor PR. **Open question for the maintainer:** would you prefer a GitHub issue for this, or should #3 be skipped for now? It can alternatively be built as a separate local / fork-only feature.

## Breaking changes
None. Only error handling / validation improved; the response shape of successful calls is unchanged.

## Impact on clients
Clients now get correct 501/413/400 instead of misleading 404/500. `tasks` id >512 or body >1MB → clear error instead of a CLI crash.
